### PR TITLE
feat: add /timestamp to make timestamp mentions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,12 +17,14 @@
         "googleapis": "^144.0.0",
         "image-downloader": "^4.3.0",
         "lodash": "^4.17.21",
+        "luxon": "^3.6.1",
         "mongoose": "^7.0.3",
         "zod": "^3.23.8"
       },
       "devDependencies": {
         "@types/cheerio": "^0.22.35",
         "@types/lodash": "^4.17.16",
+        "@types/luxon": "^3.6.2",
         "@types/mongodb": "^4.0.6",
         "@types/node": "^18.15.10",
         "copyfiles": "^2.4.1",
@@ -202,6 +204,13 @@
       "version": "4.17.16",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
       "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/luxon": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.6.2.tgz",
+      "integrity": "sha512-R/BdP7OxEMc44l2Ex5lSXHoIXTB2JLNa3y2QISIbr58U/YcsffyQrYW//hZSdrfxrjRZj3GcUoxMPGdO8gSYuw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1135,6 +1144,15 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/luxon": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,14 @@
     "googleapis": "^144.0.0",
     "image-downloader": "^4.3.0",
     "lodash": "^4.17.21",
+    "luxon": "^3.6.1",
     "mongoose": "^7.0.3",
     "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.35",
     "@types/lodash": "^4.17.16",
+    "@types/luxon": "^3.6.2",
     "@types/mongodb": "^4.0.6",
     "@types/node": "^18.15.10",
     "copyfiles": "^2.4.1",

--- a/src/features/convenience/timestamp.command.ts
+++ b/src/features/convenience/timestamp.command.ts
@@ -1,5 +1,10 @@
 import {
+  bold,
   codeBlock,
+  Colors,
+  EmbedBuilder,
+  inlineCode,
+  italic,
   SlashCommandBuilder,
   time,
   TimestampStyles,
@@ -10,7 +15,7 @@ import {
 import type { DateTime } from "luxon";
 
 import { SlashCommandHandler } from "../../abc/command.abc";
-import type { UnixSeconds } from "../../types/branded.types";
+import type { UnixSeconds, UrlString } from "../../types/branded.types";
 import {
   Month,
   MONTH_NAMES,
@@ -18,6 +23,7 @@ import {
   type IDateClient,
 } from "../../utils/date.utils";
 import { makeErrorEmbed } from "../../utils/errors.utils";
+import { quietHyperlink, toBulletedList } from "../../utils/formatting.utils";
 
 const MONTH_CHOICES: APIApplicationCommandOptionChoice<Month>[] = MONTH_NAMES
   .map(name => ({ name: `${name} (${Month[name]})`, value: Month[name] }));
@@ -60,8 +66,12 @@ class TimestampCommand extends SlashCommandHandler {
   public override readonly definition = new SlashCommandBuilder()
     .setName("timestamp")
     .setDescription(
-      "Format a timestamp mention based on input date/time in UCLA time " +
+      "Format a timestamp mention based on input date/time, in UCLA time " +
       `(${TimestampCommand.UCLA_TIMEZONE}).`,
+    )
+    .addBooleanOption(input => input
+      .setName("help")
+      .setDescription("Display help about timestamps (ignore other options)."),
     )
     .addIntegerOption(input => input
       .setName("year")
@@ -114,6 +124,14 @@ class TimestampCommand extends SlashCommandHandler {
   public override async execute(
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
+    const help = interaction.options.getBoolean("help");
+
+    if (help) {
+      const embed = this.formatHelpEmbed();
+      await interaction.reply({ embeds: [embed], ephemeral: true });
+      return;
+    }
+
     const style = interaction.options.getString(
       "style",
     ) as TimestampStylesString | null;
@@ -164,6 +182,66 @@ class TimestampCommand extends SlashCommandHandler {
     }
 
     return dateTime;
+  }
+
+  private formatHelpEmbed(): EmbedBuilder {
+    const now = this.dateClient.getNow();
+
+    const example = `Example rendered mention: ${time(now)}`;
+
+    const commandDescription = (
+      `Format a ${bold("timestamp mention")}, which encodes a date/time that ` +
+      "automatically renders in every user's current timezone. You can also " +
+      `do neat things like using the ${italic("relative time")} format style ` +
+      "to render countdowns. This command in particular will treat input as " +
+      `UCLA time (${inlineCode(TimestampCommand.UCLA_TIMEZONE)}).`
+    );
+
+    const syntaxOverview = (
+      "The syntax of a timestamp mention is:\n" +
+      codeBlock("<t:UNIX_TIMESTAMP>") +
+      "Or with a format style code:\n" +
+      codeBlock("<t:UNIX_TIMESTAMP:STYLE>") +
+      "You can also generate Unix timestamps using " +
+      quietHyperlink(
+        "this online tool",
+        "https://www.unixtimestamp.com" as UrlString,
+      ) + "."
+    );
+
+    const formatStylesReference = bold("Format Styles Reference") + "\n" +
+      toBulletedList(STYLE_CHOICES.map(choice => {
+        const { name: displayName, value } = choice;
+        // Discard the (e.g. ...) from the choice display name, we'll replace
+        // it with an actual rendered timestamp.
+        const name = displayName.slice(0, displayName.indexOf("(") - 1);
+        const mention = time(now, value);
+        return (
+          `${inlineCode(value)}: ${name} (${inlineCode(mention)} => ${mention})`
+        );
+      }));
+
+    const optionsReference = bold("Options Reference") + "\n" + toBulletedList([
+      "If you omit any of the date/time units (year, month, second, etc.), " +
+      "they default to those of the current time.",
+
+      "By default, the raw timestamp text is returned ephemerally for your " +
+      `copy-paste. You can set ${inlineCode("render")} to directly render ` +
+      "(publicly) the timestamp instead.",
+    ]);
+
+    const combinedDescription = [
+      example,
+      commandDescription,
+      syntaxOverview,
+      formatStylesReference,
+      optionsReference,
+    ].join("\n\n");
+
+    return new EmbedBuilder()
+      .setColor(Colors.Green)
+      .setTitle(`${this.id} Help`)
+      .setDescription(combinedDescription);
   }
 }
 

--- a/src/features/convenience/timestamp.command.ts
+++ b/src/features/convenience/timestamp.command.ts
@@ -1,0 +1,170 @@
+import {
+  codeBlock,
+  SlashCommandBuilder,
+  time,
+  TimestampStyles,
+  type APIApplicationCommandOptionChoice,
+  type ChatInputCommandInteraction,
+  type TimestampStylesString,
+} from "discord.js";
+import type { DateTime } from "luxon";
+
+import { SlashCommandHandler } from "../../abc/command.abc";
+import type { UnixSeconds } from "../../types/branded.types";
+import {
+  Month,
+  MONTH_NAMES,
+  SystemDateClient,
+  type IDateClient,
+} from "../../utils/date.utils";
+import { makeErrorEmbed } from "../../utils/errors.utils";
+
+const MONTH_CHOICES: APIApplicationCommandOptionChoice<Month>[] = MONTH_NAMES
+  .map(name => ({ name: `${name} (${Month[name]})`, value: Month[name] }));
+
+const STYLE_CHOICES: APIApplicationCommandOptionChoice<TimestampStylesString>[]
+  = [
+    {
+      name: "Short Time (e.g. 9:01 AM)",
+      value: TimestampStyles.ShortTime,
+    },
+    {
+      name: "Long Time (e.g. 9:01:00 AM)",
+      value: TimestampStyles.LongTime,
+    },
+    {
+      name: "Short Date (e.g. 11/28/2018)",
+      value: TimestampStyles.ShortDate,
+    },
+    {
+      name: "Long Date (e.g. November 28, 2018)",
+      value: TimestampStyles.LongDate,
+    },
+    {
+      name: "Short Date/Time (e.g. November 28, 2018 9:01 AM)",
+      value: TimestampStyles.ShortDateTime,
+    },
+    {
+      name: "Long Date/Time (e.g. Wednesday, November 28, 2018 9:01 AM)",
+      value: TimestampStyles.LongDateTime,
+    },
+    {
+      name: "Relative Time (e.g. in 2 days)",
+      value: TimestampStyles.RelativeTime,
+    },
+  ];
+
+class TimestampCommand extends SlashCommandHandler {
+  private static readonly UCLA_TIMEZONE = "America/Los_Angeles";
+
+  public override readonly definition = new SlashCommandBuilder()
+    .setName("timestamp")
+    .setDescription(
+      "Format a timestamp mention based on input date/time in UCLA time " +
+      `(${TimestampCommand.UCLA_TIMEZONE}).`,
+    )
+    .addIntegerOption(input => input
+      .setName("year")
+      .setDescription("Year.")
+      .setMinValue(1970),
+    )
+    .addIntegerOption(input => input
+      .setName("month")
+      .setDescription("Month.")
+      .addChoices(...MONTH_CHOICES),
+    )
+    .addIntegerOption(input => input
+      .setName("day")
+      .setDescription("Day of the month.")
+      .setMinValue(1)
+      .setMaxValue(31),
+    )
+    .addIntegerOption(input => input
+      .setName("hour")
+      .setDescription("Hour of the day (24 hour clock)."),
+    )
+    .addIntegerOption(input => input
+      .setName("minute")
+      .setDescription("Minute of the hour.")
+      .setMinValue(0)
+      .setMaxValue(59),
+    )
+    .addIntegerOption(input => input
+      .setName("second")
+      .setDescription("Second of the minute.")
+      .setMinValue(0)
+      .setMaxValue(59),
+    )
+    .addStringOption(input => input
+      .setName("style")
+      .setDescription("Format style.")
+      .addChoices(...STYLE_CHOICES),
+    )
+    .addBooleanOption(input => input
+      .setName("render")
+      .setDescription(
+        "Render the timestamp mention instead of returning its raw text " +
+        "for copy-paste.",
+      ),
+    )
+    .toJSON();
+
+  public constructor(private readonly dateClient: IDateClient) { super(); }
+
+  public override async execute(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    const style = interaction.options.getString(
+      "style",
+    ) as TimestampStylesString | null;
+    const render = interaction.options.getBoolean("render");
+
+    const dateTime = this.resolveDateTime(interaction.options);
+    if (typeof dateTime === "string") {
+      const explanation = dateTime;
+      await interaction.reply({
+        embeds: [makeErrorEmbed(
+          `Your provided datetime is invalid:\n${codeBlock(explanation)}`,
+        )],
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const timestamp = dateTime.toUnixInteger() as UnixSeconds;
+
+    const mention = style === null
+      ? time(timestamp)
+      : time(timestamp, style);
+
+    const content = render
+      ? mention
+      : codeBlock(mention);
+
+    await interaction.reply({ content, ephemeral: !render });
+  }
+
+  private resolveDateTime(
+    options: ChatInputCommandInteraction["options"],
+  ): DateTime | string {
+    const year = options.getInteger("year") ?? undefined;
+    const month = (options.getInteger("month") as Month | null) ?? undefined;
+    const day = options.getInteger("day") ?? undefined;
+    const hour = options.getInteger("hour") ?? undefined;
+    const minute = options.getInteger("minute") ?? undefined;
+    const second = options.getInteger("second") ?? undefined;
+
+    const dateTime = this.dateClient.getDateTime(
+      { year, month, day, hour, minute, second },
+      TimestampCommand.UCLA_TIMEZONE,
+    );
+
+    if (dateTime.invalidReason !== null) {
+      return dateTime.invalidExplanation ?? dateTime.invalidReason;
+    }
+
+    return dateTime;
+  }
+}
+
+export default new TimestampCommand(new SystemDateClient());

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -1,8 +1,10 @@
+import { DateTime, type DateObjectUnits } from "luxon";
 import type { UnixSeconds } from "../types/branded.types";
 
 export interface IDateClient {
   getNow(): UnixSeconds;
   getDate(seconds: UnixSeconds): Date;
+  getDateTime(units: DateObjectUnits, zone?: string): DateTime;
 }
 
 export class SystemDateClient implements IDateClient {
@@ -13,4 +15,28 @@ export class SystemDateClient implements IDateClient {
   public getDate(seconds: UnixSeconds): Date {
     return new Date(seconds * 1000);
   }
+
+  public getDateTime(units: DateObjectUnits, zone?: string): DateTime {
+    return DateTime.fromObject(units, { zone });
+  }
 }
+
+export enum Month {
+  January = 1,
+  February,
+  March,
+  April,
+  May,
+  June,
+  July,
+  August,
+  September,
+  October,
+  November,
+  December,
+}
+
+export type MonthName = keyof typeof Month;
+
+export const MONTH_NAMES = Object.values(Month)
+  .filter(value => typeof value === "string") as MonthName[];


### PR DESCRIPTION
## Motivation

This can help make announced dates/times (such as for deadlines or upcoming events) look more precise and proper. This is basically a shortcut for the usual flow of:

1. Visiting the [Unix timestamp converter](https://www.unixtimestamp.com).
2. Pasting the timestamp string into Discord.
3. Wrapping it with timestamp mention syntax, probably revisiting [the style format reference](https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa) because you forgot.

With this command, everything can be done without leaving Discord and without having to memorize the timestamp mention syntax and the format style codes.

## Command

Signature:

```
/timestamp
  [help:Boolean]
  [year:1970<=Integer]
  [month:Integer(Enum:Month)]
  [day:1<=Integer<=31]
  [hour:0<=Integer<59]
  [minute:0<=Integer<59]
  [second:0<=Integer<59]
  [style:String(Enum:TimestampStylesString)]
  [render:Boolean]
```

Most of the options are self-explanatory. They are also explained in the help embed. If `help=True`, all other options are ignored and the command returns an ephemeral embed documenting the command and timestamp mentions in general.

Example help embed response:

<img width="592" alt="image" src="https://github.com/user-attachments/assets/a90700d0-d2f4-4095-a912-9e8c8502e5b5" />

Example generated timestamp response:

<img width="411" alt="image" src="https://github.com/user-attachments/assets/a610b5db-69a9-4765-9515-ac8ffe261c1a" />

Example rendered timestamp response:

<img width="417" alt="image" src="https://github.com/user-attachments/assets/f29129a9-8a5c-4ab0-92ed-fb91a4fbe9cc" />
