### PR TITLE
feat: add /review to get info about review session

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,8 +33,14 @@ TUTORING_TRACKER_SPREADSHEET_ID=
 # URL of the seasonal public induction requirement tracker Google Sheets spreadsheet.
 PUBLIC_REQUIREMENT_TRACKER_SPREADSHEET_URL=
 
+# ID of the quarterly tutoring review events schedule Google Sheets spreadsheet.
+REVIEW_EVENTS_SPREADSHEET_ID=
+
 # Abbreviated induction season name.
 SEASON_ID='S25'
+
+# Academic quarter name.
+QUARTER_NAME='Spring 2025'
 
 # MongoDB database to use.
 DB_NAME=

--- a/src/clients/sheets.client.ts
+++ b/src/clients/sheets.client.ts
@@ -4,6 +4,7 @@ import { google, type sheets_v4 } from "googleapis";
 import { z } from "zod";
 
 import type { ISheetsClient } from "../interfaces/sheets.interface";
+import type { UrlString } from "../types/branded.types";
 import { PROJECT_ASSETS_ROOT, resolvePath } from "../utils/paths.utils";
 
 export const GOOGLE_CREDENTIALS_PATH
@@ -81,6 +82,12 @@ export class GoogleSheetsClient implements ISheetsClient {
       credentials.private_key
     );
     return new GoogleSheetsClient(googleClient, spreadsheetId, sheetName);
+  }
+
+  public static idToUrl(spreadsheetId: string): UrlString {
+    return (
+      `https://docs.google.com/spreadsheets/d/${spreadsheetId}`
+    ) as UrlString;
   }
 
   public async getRows(cellRange?: string): Promise<string[][]> {

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,6 +6,7 @@ import * as envalid from "envalid";
 
 import type {
   ChannelId,
+  QuarterName,
   SeasonId,
   UrlString,
   UserId,
@@ -29,6 +30,9 @@ const userIdValidator = makeBrandedValidator<UserId>(/^[0-9]+$/);
 const channelIdValidator = makeBrandedValidator<ChannelId>(/^[0-9]+$/);
 const urlStringValidator = envalid.url<UrlString>;
 const seasonIdValidator = makeBrandedValidator<SeasonId>(/^[FS][0-9]+$/);
+const quarterNameValidator = makeBrandedValidator<QuarterName>(
+  /^(Fall|Winter|Spring) [0-9]+$/,
+);
 
 export const ENV_SPEC = {
   BOT_TOKEN: envalid.str({
@@ -81,9 +85,20 @@ export const ENV_SPEC = {
       "Google Sheets spreadsheet.",
   }),
 
+  REVIEW_EVENTS_SPREADSHEET_ID: envalid.str({
+    desc:
+      "ID of the quarterly tutoring review events schedule " +
+      "Google Sheets spreadsheet.",
+  }),
+
   SEASON_ID: seasonIdValidator({
     desc: "Abbreviated induction season name.",
     example: "S25",
+  }),
+
+  QUARTER_NAME: quarterNameValidator({
+    desc: "Academic quarter name.",
+    example: "Spring 2025",
   }),
 
   DB_NAME: envalid.str({

--- a/src/features/tutoring/review-event.command.ts
+++ b/src/features/tutoring/review-event.command.ts
@@ -1,0 +1,126 @@
+import {
+  bold,
+  EmbedBuilder,
+  inlineCode,
+  roleMention,
+  time,
+  TimestampStyles,
+  type ApplicationCommandOptionChoiceData,
+  type AutocompleteInteraction,
+  type ChatInputCommandInteraction,
+} from "discord.js";
+
+import { SlashCommandHandler } from "../../abc/command.abc";
+import { GoogleSheetsClient } from "../../clients/sheets.client";
+import env from "../../env";
+import type { UnixSeconds } from "../../types/branded.types";
+import { EMOJI_INFORMATION, EMOJI_WARNING } from "../../utils/emojis.utils";
+import {
+  formatMailbox,
+  littleText,
+  quietHyperlink,
+  toBulletedList,
+} from "../../utils/formatting.utils";
+import { AUTOCOMPLETE_MAX_CHOICES } from "../../utils/limits.utils";
+import { ExtendedSlashCommandBuilder } from "../../utils/options.utils";
+import { TUTORING_ROLE_ID } from "../../utils/snowflakes.utils";
+import reviewSheetsService, { type ReviewEvent } from "./review-sheets.service";
+
+class ReviewEventCommand extends SlashCommandHandler {
+  public override readonly definition = new ExtendedSlashCommandBuilder()
+    .setName("review")
+    .setDescription("Get information about a review session.")
+    .addStringOption(input => input
+      .setName("event")
+      .setDescription("Name of event.")
+      .setRequired(true)
+      .setAutocomplete(true),
+    )
+    .addBroadcastOption()
+    .toJSON();
+
+  public override async execute(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    const eventName = interaction.options.getString("event", true);
+    const broadcast = interaction.options.getBoolean("broadcast");
+
+    const eventData = await reviewSheetsService.getData(eventName);
+    if (eventData === null) {
+      await this.replyError(interaction, (
+        `No event named ${inlineCode(eventName)} found!`
+      ));
+      return;
+    }
+
+    const embed = this.formatEmbed(eventData);
+    await interaction.reply({ embeds: [embed], ephemeral: !broadcast });
+  }
+
+  public override async autocomplete(
+    interaction: AutocompleteInteraction,
+  ): Promise<void> {
+    const focusedValue = interaction.options.getFocused().toLowerCase();
+
+    const eventsData = await reviewSheetsService.getAllData();
+    const eventNames = Array.from(eventsData.keys());
+    const filteredNames = eventNames.filter(name =>
+      name.toLowerCase().startsWith(focusedValue),
+    );
+
+    const choices: ApplicationCommandOptionChoiceData[] = filteredNames
+      .slice(0, AUTOCOMPLETE_MAX_CHOICES)
+      .map(name => ({ name, value: name }));
+
+    await interaction.respond(choices);
+  }
+
+  private formatEmbed(eventData: ReviewEvent): EmbedBuilder {
+    const professorInfo
+      = formatMailbox(eventData.professor.name, eventData.professor.email);
+
+    const hostNames = [...eventData.leadHosts, ...eventData.hosts];
+
+    const eventDateUnix
+      = eventData.eventDate?.toUnixInteger() as UnixSeconds | undefined;
+    const testDateUnix
+      = eventData.testDate?.toUnixInteger() as UnixSeconds | undefined;
+    const eventDateMention = (eventDateUnix === undefined)
+      ? ""
+      : time(eventDateUnix, TimestampStyles.ShortDate);
+    const testDateMention = (testDateUnix === undefined)
+      ? ""
+      : time(testDateUnix, TimestampStyles.ShortDate);
+
+    const lines = [
+      `${bold("Professor:")} ${professorInfo}`,
+      `${bold("Location:")} ${eventData.location}`,
+      `${bold("Hosts:")} ${hostNames.join(", ")}`,
+      eventDateMention ? `${bold("Event Date:")} ${eventDateMention}` : "",
+      testDateMention ? `${bold("Test Date:")} ${testDateMention}` : "",
+    ].filter(Boolean);
+    const body = toBulletedList(lines);
+
+    const moreInformation = (
+      `${EMOJI_INFORMATION} Review sessions are hosted by our ` +
+      `${roleMention(TUTORING_ROLE_ID)} committee.`
+    );
+
+    const spreadsheetHyperlink = quietHyperlink(
+      "UPE Tutoring events spreadsheet",
+      GoogleSheetsClient.idToUrl(env.REVIEW_EVENTS_SPREADSHEET_ID),
+    );
+    const disclaimer = littleText(
+      `${EMOJI_WARNING} This is an experimental feature. You can use the ` +
+      `${spreadsheetHyperlink} as the source of truth.`,
+    );
+
+    const description = [body, moreInformation, disclaimer].join("\n\n");
+
+    return new EmbedBuilder()
+      .setTitle(eventData.name)
+      .setDescription(description);
+  }
+}
+
+export default new ReviewEventCommand();

--- a/src/features/tutoring/review-sheets.service.ts
+++ b/src/features/tutoring/review-sheets.service.ts
@@ -1,0 +1,149 @@
+import { DateTime } from "luxon";
+import { z } from "zod";
+
+import { SheetsService } from "../../abc/sheets.abc";
+import { GoogleSheetsClient } from "../../clients/sheets.client";
+import env from "../../env";
+import { asMutable } from "../../types/generic.types";
+import { SystemDateClient } from "../../utils/date.utils";
+import { toCount } from "../../utils/formatting.utils";
+
+enum Column {
+  Event = 0,
+  Professor,
+  EventDate,
+  TestDate,
+  Location,
+  LeadHosts,
+  Hosts,
+  BackupHosts,
+  ExpectedAttendance,
+}
+
+const REVIEW_EVENT_ROW_FIELDS = [
+  z.string().trim(), // Event name; (blank).
+  z.string().trim(), // Professor email; Professor name.
+  z.string().trim(), // Event date; (day of the week).
+  z.string().trim(), // Test date; (day of the week).
+  z.string().trim(), // Location; (blank).
+  z.string().trim(), // Lead host 1; Lead host 2.
+  z.string().trim(), // Host 1; Host 2.
+  z.string().trim(), // Backup host 1; Backup host 2.
+  z.string().trim(), // Expected attendance; (blank).
+] as const;
+
+const ReviewEventRowSchema = z.tuple(
+  asMutable(REVIEW_EVENT_ROW_FIELDS),
+).rest(z.any());
+
+export type ReviewEvent = {
+  name: string;
+  professor: {
+    name: string;
+    email: string;
+  };
+  eventDate?: DateTime<true>;
+  testDate?: DateTime<true>;
+  location: string;
+  leadHosts: string[];
+  hosts: string[];
+  backupHosts: string[];
+  expectedAttendance?: number;
+};
+
+export class ReviewEventSheetsService
+  extends SheetsService<ReviewEvent, "name"> {
+
+  protected override readonly key = "name";
+
+  protected override async *parseData(
+    rows: string[][],
+  ): AsyncIterable<ReviewEvent> {
+    // Start at 1 to skip the header row.
+    for (let rowIndex = 1; rowIndex < rows.length; rowIndex += 2) {
+      const row1 = rows[rowIndex];
+      const row2 = rows[rowIndex + 1];
+      // Start of comments.
+      if (row1.length === 0) {
+        break;
+      }
+      const entry = this.parseEntry(row1, row2);
+      if (entry !== null) {
+        yield entry;
+      }
+    }
+  }
+
+  private parseEntry(row1: string[], row2: string[]): ReviewEvent | null {
+    const paddedRow1 = this.padRow(row1, REVIEW_EVENT_ROW_FIELDS.length);
+    const paddedRow2 = this.padRow(row2, REVIEW_EVENT_ROW_FIELDS.length);
+
+    const validatedRow1 = ReviewEventRowSchema.safeParse(paddedRow1);
+    const validatedRow2 = ReviewEventRowSchema.safeParse(paddedRow2);
+    if (!validatedRow1.success || !validatedRow2.success) {
+      return null;
+    }
+
+    const { data: data1 } = validatedRow1;
+    const { data: data2 } = validatedRow2;
+
+    const eventName = data1[Column.Event];
+    const professor = {
+      name: data2[Column.Professor],
+      email: data1[Column.Professor],
+    };
+    const eventDate = this.resolveDateString(data1[Column.EventDate]);
+    const location = data1[Column.Location];
+    const testDate = this.resolveDateString(data1[Column.TestDate]);
+    const leadHosts = [
+      data1[Column.LeadHosts],
+      data2[Column.LeadHosts],
+    ].filter(Boolean);
+    const hosts = [
+      data1[Column.Hosts],
+      data2[Column.Hosts],
+    ].filter(Boolean);
+    const backupHosts = [
+      data1[Column.BackupHosts],
+      data2[Column.BackupHosts],
+    ].filter(Boolean);
+    const expectedAttendance = toCount(data1[Column.ExpectedAttendance]);
+
+    return {
+      name: eventName,
+      professor,
+      eventDate: eventDate ?? undefined,
+      testDate: testDate ?? undefined,
+      location,
+      leadHosts,
+      hosts,
+      backupHosts,
+      expectedAttendance: expectedAttendance ?? undefined,
+    };
+  }
+
+  private resolveDateString(text: string): DateTime<true> | null {
+    // Ref: https://moment.github.io/luxon/#/parsing?id=table-of-tokens.
+    const format1 = "M/d";
+    const format2 = "M/d/y";
+    let dateTime = DateTime.fromFormat(text, format1);
+    if (dateTime.isValid) {
+      return dateTime;
+    }
+    dateTime = DateTime.fromFormat(text, format2);
+    if (dateTime.isValid) {
+      return dateTime;
+    }
+    return null;
+  }
+}
+
+// Dependency-inject the production clients.
+const sheetsClient = GoogleSheetsClient.fromCredentialsFile(
+  env.REVIEW_EVENTS_SPREADSHEET_ID,
+  env.QUARTER_NAME,
+);
+export default new ReviewEventSheetsService(
+  sheetsClient,
+  new SystemDateClient(),
+);

--- a/src/features/tutoring/review-sheets.service.ts
+++ b/src/features/tutoring/review-sheets.service.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { SheetsService } from "../../abc/sheets.abc";
 import { GoogleSheetsClient } from "../../clients/sheets.client";
 import env from "../../env";
+import type { Seconds } from "../../types/branded.types";
 import { asMutable } from "../../types/generic.types";
 import { SystemDateClient } from "../../utils/date.utils";
 import { toCount } from "../../utils/formatting.utils";
@@ -55,6 +56,9 @@ export class ReviewEventSheetsService
   extends SheetsService<ReviewEvent, "name"> {
 
   protected override readonly key = "name";
+
+  // This spreadsheet doesn't change very often.
+  protected override refreshInterval = 3600 as Seconds;
 
   protected override async *parseData(
     rows: string[][],

--- a/src/types/branded.types.ts
+++ b/src/types/branded.types.ts
@@ -36,3 +36,7 @@ export type UserId = Branded<Snowflake, "UserId">;
 export type CommandId = Branded<Snowflake, "CommandId">;
 
 export type SeasonId = Branded<`${"F" | "S"}${number}`, "SeasonId">;
+export type QuarterName = Branded<
+  `${"Fall" | "Winter" | "Spring"} ${number}`,
+  "QuarterName"
+>;

--- a/src/utils/formatting.utils.ts
+++ b/src/utils/formatting.utils.ts
@@ -117,6 +117,15 @@ export function splitIntoEmbedPages(
   return embeds;
 }
 
+export function formatMailbox<Name extends string, Email extends string>(
+  name: Name,
+  email: Email,
+): `${Name} <${Email}>`;
+export function formatMailbox<Name extends string, Email extends string>(
+  name: Name,
+  email: Email,
+  escaped: true,
+): `${Name} \\<${Email}\\>`;
 /**
  * Format a name and email into the mailbox format as defined by RFC 5322.
  *
@@ -125,6 +134,7 @@ export function splitIntoEmbedPages(
 export function formatMailbox<Name extends string, Email extends string>(
   name: Name,
   email: Email,
-): `${Name} <${Email}>` {
-  return `${name} <${email}>`;
+  escaped?: boolean,
+): `${Name} <${Email}>` | `${Name} \\<${Email}\\>` {
+  return escaped ? `${name} \\<${email}\\>` : `${name} <${email}>`;
 }

--- a/src/utils/formatting.utils.ts
+++ b/src/utils/formatting.utils.ts
@@ -116,3 +116,15 @@ export function splitIntoEmbedPages(
 
   return embeds;
 }
+
+/**
+ * Format a name and email into the mailbox format as defined by RFC 5322.
+ *
+ * Ref: https://www.rfc-editor.org/rfc/rfc5322#section-3.4
+ */
+export function formatMailbox<Name extends string, Email extends string>(
+  name: Name,
+  email: Email,
+): `${Name} <${Email}>` {
+  return `${name} <${email}>`;
+}


### PR DESCRIPTION
**Motivation:** people often ask about details for a tutoring review session. This command can be used by ordinary server members to get information, or it can be used by officers to check an event's hosts (points of contact) to relay queries.

Command signature:

```
/review <event:String> [broadcast:Boolean]
```

Options semantics:

- `event` is the name of the the review session event e.g. `CS 32 Midterm 1`.
- `event` is **autocomplete-enabled**.
- `broadcast` disables ephemeral success responses (ephemeral is default).

This responds with an embed with information about a review session as parsed from the tutoring committee's events schedule spreadsheet. The parsing is implemented with a service class derived from the `SheetsService` ABC (#8).