### PR TITLE
feat: add /assignofficers to update officer users

### DIFF
--- a/src/abc/sheets.abc.ts
+++ b/src/abc/sheets.abc.ts
@@ -74,6 +74,8 @@ export abstract class SheetsService<
   }
 }
 
+export class SheetsRowTransformError extends Error { }
+
 /**
  * Extraction and generalization of the most common sheet parsing flow:
  *
@@ -112,6 +114,10 @@ export abstract class RowWiseSheetsService<
           await this.handleParseError(error, rowIndex);
           continue;
         }
+        if (error instanceof SheetsRowTransformError) {
+          await this.handleTransformError(error, rowIndex);
+          continue;
+        }
         throw error;
       }
     }
@@ -133,6 +139,15 @@ export abstract class RowWiseSheetsService<
   ): Awaitable<void> {
     console.error(
       `Error validating data (row ${rowIndex + 1}): ${error.message}`,
+    );
+  }
+
+  protected handleTransformError(
+    error: SheetsRowTransformError,
+    rowIndex: number,
+  ): Awaitable<void> {
+    console.error(
+      `Error transforming data (row ${rowIndex + 1}): ${error.message}`,
     );
   }
 }

--- a/src/features/moderation/officer-assign.command.ts
+++ b/src/features/moderation/officer-assign.command.ts
@@ -323,7 +323,7 @@ class OfficerAssignCommand extends SlashCommandHandler {
         description += `\n\nSee: ${logsHyperlink}`;
       }
       return new EmbedBuilder()
-        .setTitle("Officer Roles Updated")
+        .setTitle("Officers Updated")
         .setDescription(description)
         .setColor(Colors.Green);
     }
@@ -353,7 +353,7 @@ class OfficerAssignCommand extends SlashCommandHandler {
     }
 
     return new EmbedBuilder()
-      .setTitle("Officer Updated [SOME ERROR]")
+      .setTitle("Officers Updated [SOME ERROR]")
       .setDescription(errorDescriptionLines.join("\n"))
       .setColor(Colors.Red);
   }

--- a/src/features/moderation/officer-assign.command.ts
+++ b/src/features/moderation/officer-assign.command.ts
@@ -1,0 +1,307 @@
+import {
+  bold,
+  channelMention,
+  Colors,
+  DiscordAPIError,
+  EmbedBuilder,
+  hyperlink,
+  inlineCode,
+  roleMention,
+  SlashCommandBuilder,
+  userMention,
+  type ChatInputCommandInteraction,
+  type Collection,
+  type ColorResolvable,
+  type Guild,
+  type GuildMember,
+  type Message,
+} from "discord.js";
+
+import type { SlashCommandCheck } from "../../abc/check.abc";
+import { SlashCommandHandler } from "../../abc/command.abc";
+import {
+  Privilege,
+  PrivilegeCheck,
+} from "../../middleware/privilege.middleware";
+import channelsService from "../../services/channels.service";
+import type { RoleId } from "../../types/branded.types";
+import { EMOJI_ALERT, EMOJI_WARNING } from "../../utils/emojis.utils";
+import {
+  DIRECTORS_ROLE_ID,
+  OFFICERS_ROLE_ID,
+} from "../../utils/snowflakes.utils";
+import {
+  COMMITTEE_ROLE_MAP,
+  Title,
+  type Committee,
+} from "../../utils/upe.utils";
+import officersServiceFactory, { type OfficerData } from "./officers.service";
+
+class OfficerAssignCommand extends SlashCommandHandler {
+  public override readonly definition = new SlashCommandBuilder()
+    .setName("assignofficers")
+    .setDescription(
+      "Assign roles to users based on officer contact information spreadsheet",
+    )
+    .addStringOption(input => input
+      .setName("spreadsheet_url")
+      .setDescription("URL to Google Sheets responses spreadsheet")
+      .setRequired(true),
+    )
+    .toJSON();
+
+  public override readonly checks: SlashCommandCheck[] = [
+    new PrivilegeCheck(this).atLeast(Privilege.Administrator),
+  ];
+
+  public override async execute(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    const { guild, options } = interaction;
+    if (guild === null) {
+      await this.replyError(interaction, (
+        "This command can only be used in the server."
+      ));
+      return;
+    }
+
+    const spreadsheetUrl = options.getString("spreadsheet_url", true);
+    const spreadsheetId = this.extractSpreadsheetId(spreadsheetUrl);
+    if (spreadsheetId === null) {
+      await this.replyError(interaction, (
+        `${inlineCode(spreadsheetUrl)} is not a valid Google Sheets URL.`
+      ));
+      return;
+    }
+
+    const commandResponse = await interaction.deferReply({ fetchReply: true });
+
+    // Fetch officer contact information.
+
+    const officersService = officersServiceFactory.make(spreadsheetId);
+    const allData = await officersService.getAllData(true);
+
+    // The actual updating. Individual output is written to logs sink channel.
+
+    const [
+      missingUsernames,
+      missingRoles,
+    ] = await this.processAllOfficers(guild, allData, commandResponse);
+
+    // Report success/missing by updating the original command response.
+
+    const embed = this.prepareResponseEmbed(
+      allData.size,
+      spreadsheetUrl,
+      missingUsernames,
+      missingRoles,
+    );
+    await interaction.editReply({ embeds: [embed] });
+  }
+
+  private extractSpreadsheetId(url: string): string | null {
+    const SPREADSHEET_URL_RE
+      = /https:\/\/docs\.google\.com\/spreadsheets\/d\/([a-z0-9_-]+)($|\/)/i;
+    const match = SPREADSHEET_URL_RE.exec(url);
+    return match == null ? null : match[1];
+  }
+
+  private async processAllOfficers(
+    guild: Guild,
+    allData: Collection<string, OfficerData>,
+    commandResponse: Message,
+  ): Promise<[missingUsernames: string[], missingRoles: Committee[]]> {
+    const missingUsernames: string[] = [];
+    const missingRoles: Committee[] = [];
+
+    for (const [discordUsername, data] of allData) {
+      const members = await guild.members.fetch({
+        query: discordUsername,
+        limit: 1,
+      });
+      const [member] = members.values();
+
+      if (member === undefined) {
+        missingUsernames.push(discordUsername);
+        continue;
+      }
+
+      await this.processOfficer(member, data, missingRoles, commandResponse);
+    }
+
+    return [missingUsernames, missingRoles];
+  }
+
+  private async processOfficer(
+    member: GuildMember,
+    data: OfficerData,
+    missingRoles: Committee[],
+    commandResponse: Message,
+  ): Promise<void> {
+    // Everyone gets the officers blanket role.
+
+    const officerGiven = await this.addRoleIfNotHave(member, OFFICERS_ROLE_ID);
+
+    // Now give them their specific committee role.
+
+    const committeeRoleId = COMMITTEE_ROLE_MAP.get(data.committee);
+    let committeeGiven = false;
+    if (committeeRoleId === undefined) {
+      missingRoles.push(data.committee);
+    }
+    else {
+      committeeGiven = await this.addRoleIfNotHave(member, committeeRoleId);
+    }
+
+    // Now give them the director role if needed.
+
+    let directorGiven = false;
+    if (data.title === Title.Director) {
+      directorGiven = await this.addRoleIfNotHave(member, DIRECTORS_ROLE_ID);
+    }
+
+    // Acknowledge.
+
+    await this.sendIndividualAcknowledgement(
+      officerGiven,
+      committeeGiven,
+      committeeRoleId,
+      directorGiven,
+      member,
+      commandResponse,
+    );
+  }
+
+  private async sendIndividualAcknowledgement(
+    officerGiven: boolean,
+    committeeGiven: boolean,
+    committeeRoleId: RoleId | undefined,
+    directorGiven: boolean,
+    member: GuildMember,
+    commandResponse: Message,
+  ): Promise<void> {
+    const rolesGivenString = [
+      officerGiven ? OFFICERS_ROLE_ID : "",
+      committeeGiven && committeeRoleId ? committeeRoleId : "",
+      directorGiven ? DIRECTORS_ROLE_ID : "",
+    ].filter(Boolean).map(roleMention).join(", ");
+
+    // The member was parsed from the data but they already have all the roles
+    // they need. No need to clutter the output.
+    if (!rolesGivenString) {
+      return;
+    }
+
+    const description = `Gave ${rolesGivenString} to ${userMention(member.id)}`;
+
+    const logSink = channelsService.getLogSink();
+    if (logSink === null) {
+      console.warn(
+        `LOG SINK CHANNEL IS MISSING, CANNOT ACKNOWLEDGE ${this.id} ` +
+        `PROCESSING FOR MEMBER @${member.user.username}: ${description}`
+      );
+      return;
+    }
+
+    let committeeRoleColor: ColorResolvable | null = null;
+    if (committeeRoleId !== undefined) {
+      const committeeRole = member.roles.cache.get(committeeRoleId);
+      if (committeeRole !== undefined) {
+        committeeRoleColor = committeeRole.color;
+      }
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("Officer Roles Updated")
+      .setDescription(description)
+      .setColor(committeeRoleColor);
+
+    try {
+      await logSink.send({
+        content: `${bold(this.id)}: ${commandResponse.url}`,
+        embeds: [embed],
+      });
+    }
+    // Don't compromise the rest of the handling.
+    catch (error) {
+      if (error instanceof DiscordAPIError) {
+        console.error(`ERROR IN SENDING ${this.id} ACK TO LOG SINK:`);
+        console.error(error);
+        try { await channelsService.sendDevError(error); } catch { }
+      }
+      throw error;
+    }
+  }
+
+  private async addRoleIfNotHave(
+    member: GuildMember,
+    roleId: RoleId,
+  ): Promise<boolean> {
+    if (member.roles.cache.has(roleId)) {
+      return false;
+    }
+    await member.roles.add(roleId);
+    return true;
+  }
+
+  private prepareResponseEmbed(
+    numOfficers: number,
+    spreadsheetUrl: string,
+    missingUsernames: string[],
+    missingRoles: Committee[],
+  ): EmbedBuilder {
+    const spreadsheetHyperlink = hyperlink(
+      "officer contact information spreadsheet",
+      spreadsheetUrl,
+    );
+
+    const logSink = channelsService.getLogSink();
+    const logsHyperlink = logSink ? channelMention(logSink.id) : null;
+
+    // Success case.
+    if (missingUsernames.length === 0 && missingRoles.length === 0) {
+      let description = (
+        `Successfully updated all ${bold(numOfficers.toString())} officers ` +
+        `using data from the ${spreadsheetHyperlink}.`
+      );
+      if (logsHyperlink !== null) {
+        description += `\n\nSee: ${logsHyperlink}`;
+      }
+      return new EmbedBuilder()
+        .setTitle("Officer Roles Updated")
+        .setDescription(description)
+        .setColor(Colors.Green);
+    }
+
+    const errorDescriptionLines = [
+      `Of the ${bold(numOfficers.toString())} officers parsed from the ` +
+      `${spreadsheetHyperlink}, we have:`,
+    ];
+    if (missingUsernames.length > 0) {
+      const missingUsernamesString = missingUsernames
+        .map(username => inlineCode(`@${username}`))
+        .join(", ");
+      errorDescriptionLines.push(
+        `- ${EMOJI_WARNING} Missing usernames: ${missingUsernamesString}`,
+      );
+    }
+    if (missingRoles.length > 0) {
+      const missingRolesString = missingRoles.map(inlineCode).join(", ");
+      errorDescriptionLines.push(
+        `- ${EMOJI_ALERT} Missing role for committees: ${missingRolesString}`,
+      );
+    }
+    if (logsHyperlink !== null) {
+      errorDescriptionLines.push(
+        `See successfully updated officers: ${logsHyperlink}`,
+      );
+    }
+
+    return new EmbedBuilder()
+      .setTitle("Officer Roles Updated [SOME ERROR]")
+      .setDescription(errorDescriptionLines.join("\n"))
+      .setColor(Colors.Red);
+  }
+}
+
+export default new OfficerAssignCommand();

--- a/src/features/moderation/officer-assign.command.ts
+++ b/src/features/moderation/officer-assign.command.ts
@@ -240,7 +240,7 @@ class OfficerAssignCommand extends SlashCommandHandler {
     if (member.roles.cache.has(roleId)) {
       return false;
     }
-    await member.roles.add(roleId);
+    await member.roles.add(roleId, this.id);
     return true;
   }
 

--- a/src/features/moderation/officers.service.ts
+++ b/src/features/moderation/officers.service.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert";
+
+import { Collection } from "discord.js";
+import { z } from "zod";
+
+import { RowWiseSheetsService } from "../../abc/sheets.abc";
+import { GoogleSheetsClient } from "../../clients/sheets.client";
+import { UpeMajor } from "../../services/inductee-sheets.service";
+import type { Quarter, QuarterName } from "../../types/branded.types";
+import { SystemDateClient } from "../../utils/date.utils";
+import {
+  getCommitteeFromName,
+  getTitleFromName,
+  type Committee,
+  type CommitteeName,
+  type Title,
+  type TitleName,
+} from "../../utils/upe.utils";
+import { cleanProvidedUsername } from "../inductee-role/input.utils";
+
+enum Column {
+  Timestamp = 0,
+  Email,
+  LegalFirst,
+  LegalLast,
+  PreferredFull,
+  Pronouns,
+  BoardPosition,
+  Major,
+  StudentYear,
+  GraduationQuarter,
+  PreferredEmail,
+  PhoneNumber,
+  DiscordUsername,
+  ActiveQuarters,
+  Uid,
+}
+
+const ColumnSchema = z.tuple([
+  z.string().trim(),                                  // Timestamp
+  z.string().trim().email(),                          // Email
+  z.string().trim(),                                  // LegalFirst
+  z.string().trim(),                                  // LegalLast
+  z.string().trim(),                                  // PreferredFull
+  z.string().trim(),                                  // Pronouns
+  z.string().trim(),                                  // BoardPosition
+  z.nativeEnum(UpeMajor),                             // Major
+  z.string().trim(),                                  // StudentYear
+  z.string().trim(),                                  // GraduationQuarter
+  z.string().trim().email(),                          // PreferredEmail
+  z.string().trim(),                                  // PhoneNumber
+  z.string().trim().transform(cleanProvidedUsername), // DiscordUsername
+  z.string().trim(),                                  // ActiveQuarters
+  z.string().trim(),                                  // Uid
+]).rest(z.any());
+
+type ResponseRow = z.infer<typeof ColumnSchema>;
+
+export type OfficerData = {
+  legalFirst: string;
+  legalLast: string;
+  preferredName: string;
+  pronouns: string;
+  committee: Committee;
+  title: Title;
+  major: UpeMajor;
+  graduation: QuarterName;
+  preferredEmail: string;
+  phoneNumber: string;
+  discordUsername: string;
+  activeQuarters: Quarter[];
+  uid: string;
+};
+
+export class OfficersService extends RowWiseSheetsService<
+  OfficerData,
+  "discordUsername",
+  ResponseRow
+> {
+  protected override readonly key = "discordUsername";
+  protected override readonly schema = ColumnSchema;
+
+  protected override acceptRow(rowIndex: number, _row: string[]): boolean {
+    return rowIndex >= 1; // Skip header row.
+  }
+
+  protected override transformRow(validatedRow: ResponseRow): OfficerData {
+    const [
+      committee,
+      title,
+    ] = this.validateBoardPosition(validatedRow[Column.BoardPosition]);
+
+    const graduationQuarter = validatedRow[Column.GraduationQuarter];
+    this.assertQuarterName(graduationQuarter);
+
+    const activeQuarters = this.validateActiveQuarters(
+      validatedRow[Column.ActiveQuarters],
+    );
+
+    return {
+      legalFirst: validatedRow[Column.LegalFirst],
+      legalLast: validatedRow[Column.LegalLast],
+      preferredName: validatedRow[Column.PreferredFull],
+      pronouns: validatedRow[Column.Pronouns],
+      committee,
+      title,
+      major: validatedRow[Column.Major],
+      graduation: graduationQuarter,
+      preferredEmail: validatedRow[Column.PreferredEmail],
+      phoneNumber: validatedRow[Column.PhoneNumber],
+      discordUsername: validatedRow[Column.DiscordUsername],
+      activeQuarters: activeQuarters,
+      uid: validatedRow[Column.Uid],
+    };
+  }
+
+  private validateBoardPosition(
+    value: string,
+  ): [committee: Committee, title: Title] {
+    const tokens = value.split(" ");
+    const titleName = tokens.pop() as TitleName;
+    const title = getTitleFromName(titleName);
+    const committeeName = tokens.join(" ") as CommitteeName;
+    const committee = getCommitteeFromName(committeeName);
+    return [committee, title];
+  }
+
+  private validateActiveQuarters(value: string): Quarter[] {
+    const quarters: Quarter[] = [];
+    for (const token of value.split(", ")) {
+      this.assertQuarter(token);
+      quarters.push(token);
+    }
+    return quarters;
+  }
+
+  // TODO: This kind of validation should probably be promoted next to and kept
+  // as single source of truth for their respective branded types.
+
+  private assertQuarterName(value: string): asserts value is QuarterName {
+    assert(/^(Fall|Winter|Spring) [0-9]+$/.test(value));
+  }
+
+  private assertQuarter(value: string): asserts value is Quarter {
+    assert(["Fall", "Winter", "Spring"].includes(value));
+  }
+}
+
+class OfficersServiceFactory {
+  private readonly instances = new Collection<string, OfficersService>();
+
+  public make(spreadsheetId: string): OfficersService {
+    let service = this.instances.get(spreadsheetId);
+    if (service != undefined) {
+      return service;
+    }
+
+    // Dependency inject the production clients.
+    const sheetsClient = GoogleSheetsClient.fromCredentialsFile(
+      spreadsheetId,
+      "Form Responses 1",
+    );
+    service = new OfficersService(sheetsClient, new SystemDateClient());
+
+    this.instances.set(spreadsheetId, service);
+    return service;
+  }
+}
+
+export default new OfficersServiceFactory();

--- a/src/types/branded.types.ts
+++ b/src/types/branded.types.ts
@@ -36,7 +36,6 @@ export type UserId = Branded<Snowflake, "UserId">;
 export type CommandId = Branded<Snowflake, "CommandId">;
 
 export type SeasonId = Branded<`${"F" | "S"}${number}`, "SeasonId">;
-export type QuarterName = Branded<
-  `${"Fall" | "Winter" | "Spring"} ${number}`,
-  "QuarterName"
->;
+
+export type Quarter = "Fall" | "Winter" | "Spring";
+export type QuarterName = Branded<`${Quarter} ${number}`, "QuarterName">;

--- a/src/utils/data.utils.ts
+++ b/src/utils/data.utils.ts
@@ -1,0 +1,95 @@
+export class BidirectionalMap<TKey, TValue> implements Map<TKey, TValue> {
+  private forwardMap = new Map<TKey, TValue>();
+  private reverseMap = new Map<TValue, TKey>();
+
+  public constructor(initialPairs?: Iterable<[TKey, TValue]>) {
+    if (initialPairs === undefined) {
+      return;
+    }
+    for (const [key, value] of initialPairs) {
+      this.set(key, value);
+    }
+  }
+
+  public get size(): number {
+    return this.forwardMap.size;
+  }
+
+  public set(key: TKey, value: TValue): this {
+    this.forwardMap.set(key, value);
+    this.reverseMap.set(value, key);
+    return this;
+  }
+
+  public has(key: TKey): boolean {
+    return this.forwardMap.has(key);
+  }
+
+  public hasValue(value: TValue): boolean {
+    return this.reverseMap.has(value);
+  }
+
+  public get(key: TKey): TValue | undefined {
+    return this.forwardMap.get(key);
+  }
+
+  public getKey(value: TValue): TKey | undefined {
+    return this.reverseMap.get(value);
+  }
+
+  public delete(key: TKey): boolean {
+    return this.deleteByKey(key);
+  }
+
+  public deleteByKey(key: TKey): boolean {
+    const value = this.forwardMap.get(key);
+    if (value == undefined) {
+      return false;
+    }
+    this.forwardMap.delete(key);
+    this.reverseMap.delete(value);
+    return true;
+  }
+
+  public deleteByValue(value: TValue): boolean {
+    const key = this.reverseMap.get(value);
+    if (key == undefined) {
+      return false;
+    }
+    this.reverseMap.delete(value);
+    this.forwardMap.delete(key);
+    return true;
+  }
+
+  public clear(): void {
+    this.forwardMap.clear();
+    this.reverseMap.clear();
+  }
+
+  public keys() {
+    return this.forwardMap.keys();
+  }
+
+  public values() {
+    return this.reverseMap.keys();
+  }
+
+  public entries() {
+    return this.forwardMap.entries();
+  }
+
+  public forEach(
+    callbackfn: (value: TValue, key: TKey, map: Map<TKey, TValue>) => void,
+    thisArg?: any,
+  ): void {
+    this.forwardMap.forEach(callbackfn, thisArg);
+  }
+
+  public [Symbol.iterator]() {
+    return this.entries();
+  }
+
+  public get [Symbol.toStringTag](): string {
+    return this.constructor.name;
+  }
+}

--- a/src/utils/upe.utils.ts
+++ b/src/utils/upe.utils.ts
@@ -105,6 +105,28 @@ export type TeamTypeName = `${TeamType}`;
 
 export const TEAM_TYPE_NAMES: TeamTypeName[] = Object.values(TeamType);
 
+export enum Title {
+  Exec = "Exec",
+  Director = "Director",
+  Chair = "Chair",
+  // NOTE: There used to be officer "interns" as well, but that system has been
+  // abandoned.
+}
+
+export type TitleName = `${Title}`;
+
+export function getTitleFromName(
+  name: TitleName,
+): Title {
+  const title = getEnumFromName(Title, name);
+  if (title === undefined) {
+    throw new Error(
+      `${name} should have had a valid reverse mapping in title enum.`,
+    );
+  }
+  return title;
+}
+
 export const INDUCTION_LINKTREE
   = "https://linktr.ee/upe_induction" as UrlString;
 export const UPE_LINKTREE

--- a/src/utils/upe.utils.ts
+++ b/src/utils/upe.utils.ts
@@ -3,6 +3,7 @@ import { type ColorResolvable, type RoleResolvable } from "discord.js";
 import env from "../env";
 import type { RoleId, UrlString } from "../types/branded.types";
 import { getEnumFromName } from "../types/generic.types";
+import { BidirectionalMap } from "./data.utils";
 import {
   ADVOCACY_ROLE_ID,
   ALUMNI_ROLE_ID,
@@ -55,6 +56,9 @@ export function getCommitteeFromName(
   return committee;
 }
 
+/**
+ * @deprecated Use the committee-role bidirectional map instead.
+ */
 export function committeeRoleToEnum(
   role: RoleResolvable,
 ): Committee | undefined {
@@ -93,6 +97,23 @@ export function committeeRoleToEnum(
       return undefined;
   }
 }
+
+export const COMMITTEE_ROLE_MAP = new BidirectionalMap([
+  [Committee.FinanceAndFacilities, FINANCE_AND_FACILITIES_ROLE_ID],
+  [Committee.Advocacy, ADVOCACY_ROLE_ID],
+  [Committee.Alumni, ALUMNI_ROLE_ID],
+  [Committee.DesignAndPublicity, DESIGN_AND_PUBLICITY_ROLE_ID],
+  [Committee.Mentorship, MENTORSHIP_ROLE_ID],
+  [Committee.Tutoring, TUTORING_ROLE_ID],
+  [Committee.Social, SOCIAL_ROLE_ID],
+  [Committee.Web, WEB_ROLE_ID],
+  [Committee.Corporate, CORPORATE_ROLE_ID],
+  [Committee.InductionAndMembership, INDUCTION_AND_MEMBERSHIP_ROLE_ID],
+  [Committee.Entrepreneurship, ENTREPRENEURSHIP_ROLE_ID],
+  [Committee.President, PRESIDENT_ROLE_ID],
+  [Committee.InternalVicePresident, IVP_ROLE_ID],
+  [Committee.ExternalVicePresident, EVP_ROLE_ID],
+]);
 
 export enum TeamType {
   Exec = "Exec",


### PR DESCRIPTION
## Motivation

New officers are joining the UPE board. While the cohort size is small enough for manual role assignment, it would be nice to pay the cost once now and automate this process for the current and all future officer additions as well as officer role integrity checks. Furthermore, the functionality introduced in this PR implements a prerequisite for any future features that require "officer lookup". That is, similar to how we have an "inductee name service" to map between Discord usernames and preferred names, the new "officer name service" will do the same.

## Overview

This is like the officers counterpart to `/assigninductees` (alexanderhwang02/upe-discord-bot#3).

Command signature:

```
/assignofficers <spreadsheet_url:String>
```

Options semantics:
- `spreadsheet_url` is the URL to the Google Sheets spreadsheet of the officer contact information. If this is not a valid Google Sheets URL (as checked by regex), the command gracefully errors.

Note that this dynamic specification of spreadsheet URL is a departure from the convention of previous features (#2, #6, #9) that have spreadsheet ID/URLs in the `.env` file. This hopefully reduces the need for code/configuration changes between officer updates.

Access control:
- Requires privilege level `Administrator` or higher.

Response semantics:
- The command will respond to the interaction with a success/error **embed**. The error cases are invalid input or missing Discord usernames and/or committee roles. In any case, the embed will hyperlink to the bot logs channel.
- The command will stream acknowledgement embeds to the bot logs channel for each updated Discord user. An acknowledgment is only sent if a role *addition*/nickname *change* was made (so if a user already has all the roles they need & matching nickname, no API call is made for them, and no embed is sent for them, reducing clutter).

As mentioned above, this PR introduces a new service (derived from the generic Sheets parsing service, #8) to parse the officer contact information spreadsheet and expose data objects representing each officer.