### PR TITLE
feat: generalize developer status from UID to role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,6 @@ BOT_TOKEN=
 # Client application ID generated on the Discord Developer Dashboard.
 APPLICATION_ID=
 
-# Discord ID of the user developing/maintaining this bot.
-DEVELOPER_USER_ID=
-
 # Email inductees use for private queries to the Induction committee.
 INDUCTION_EMAIL=
 

--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -22,7 +22,7 @@ class ReadyListener extends DiscordEventListener<Events.ClientReady> {
     await channelsService.initialize(client);
 
     const [timeMention, relativeMention] = timestampPair(now);
-    await channelsService.getDev().send(
+    await channelsService.sendDev(
       `Bot has logged in at ${timeMention} (${relativeMention}).`,
     );
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -43,10 +43,6 @@ export const ENV_SPEC = {
     desc: "Client application ID generated on the Discord Developer Dashboard.",
   }),
 
-  DEVELOPER_USER_ID: userIdValidator({
-    desc: "Discord ID of the user developing/maintaining this bot.",
-  }),
-
   INDUCTION_EMAIL: envalid.email({
     desc: "Email inductees use for private queries to the Induction committee.",
   }),

--- a/src/features/convenience/help.command.ts
+++ b/src/features/convenience/help.command.ts
@@ -6,7 +6,6 @@ import {
   EmbedBuilder,
   roleMention,
   SlashCommandBuilder,
-  userMention,
   type ChatInputCommandInteraction,
 } from "discord.js";
 
@@ -25,7 +24,7 @@ import {
 import {
   ADVOCACY_ROLE_ID,
   CORPORATE_ROLE_ID,
-  DEVELOPER_USER_ID,
+  DEVELOPER_ROLE_ID,
   INDUCTEES_CHAT_CHANNEL_ID,
   INDUCTEES_ROLE_ID,
   INDUCTION_AND_MEMBERSHIP_ROLE_ID,
@@ -93,7 +92,7 @@ const POINTS_OF_CONTACT =
     `${roleMention(ADVOCACY_ROLE_ID)}.`,
 
     "Discord-related question or if I ever go down because bro was testing " +
-    `in prod: reach out to ${userMention(DEVELOPER_USER_ID)}.`,
+    `in prod: reach out to ${roleMention(DEVELOPER_ROLE_ID)}.`,
   ]);
 
 const COMBINED_DESCRIPTION = [

--- a/src/features/dev/shutdown.command.ts
+++ b/src/features/dev/shutdown.command.ts
@@ -10,7 +10,7 @@ import {
   Privilege,
   PrivilegeCheck,
 } from "../../middleware/privilege.middleware";
-import ChannelsService from "../../services/channels.service";
+import channelsService from "../../services/channels.service";
 import { formatContext } from "../../utils/formatting.utils";
 
 class ShutdownCommand extends SlashCommandHandler {
@@ -29,7 +29,7 @@ class ShutdownCommand extends SlashCommandHandler {
     try {
       console.warn(`${formatContext(interaction)}: shutting down the bot.`);
       await interaction.reply("Shutting down!");
-      await ChannelsService.getDev().send(
+      await channelsService.sendDev(
         `${userMention(interaction.user.id)} has shut down the bot!`,
       );
     }

--- a/src/utils/enums.utils.ts
+++ b/src/utils/enums.utils.ts
@@ -1,0 +1,10 @@
+// Because TypeScript enums are notoriously frustrating to deal with sometimes.
+
+/** Courtesy of ChatGPT. */
+function getNumericEnumValues<TEnum extends Record<string, string | number>>(
+  enumObj: TEnum
+): Array<TEnum[keyof TEnum]> {
+  return Object.values(enumObj).filter(
+    v => typeof v === "number"
+  ) as Array<TEnum[keyof TEnum]>;
+}

--- a/src/utils/snowflakes.utils.ts
+++ b/src/utils/snowflakes.utils.ts
@@ -32,16 +32,13 @@ export const EMERITUS_ROLE_ID = "854916094326341633" as RoleId;
 export const ADMINS_ROLE_ID = "778437029280612353" as RoleId;
 export const EXEC_ROLE_ID = "827989794667102248" as RoleId;
 export const DIRECTORS_ROLE_ID = "1091432095714398279" as RoleId;
+export const DEVELOPER_ROLE_ID = "1376451133354020996" as RoleId;
 export const OFFICERS_ROLE_ID = "778435056661823490" as RoleId;
 export const INTERNS_ROLE_ID = "931950245313646662" as RoleId;
 export const MEMBERS_ROLE_ID = "778438099176259674" as RoleId;
 export const INDUCTEES_ROLE_ID = "778438274695036957" as RoleId;
 export const BYTE_ROLE_ID = "899729573179162644" as RoleId;
 export const UPE_BOT_ROLE_ID = "1090790818866016337" as RoleId;
-
-// User IDs.
-
-export const { DEVELOPER_USER_ID } = env;
 
 // Channel IDs.
 


### PR DESCRIPTION
- Now that there may be multiple concurrent developers, we'll ditch the `DEVELOPER_USER_ID` system and instead use an in-server role to determine developer status.
- Refactor privilege checking to bidirectionally map privilege values and Discord roles. `highestPrivilege()` now iterates in reverse enum value order instead of using hard-coded checks for each enum member, making it automatically pick up future changes to the `Privilege` enum.
- Refactor channels service now that there may be multiple developers. Notably, "sending to dev" will broadcast to ALL developers in the role, as determined during service initialization (DM channels are snapshotted on `initialize()`, not discovered dynamically).