### PR TITLE
feat: orz different officers until all orzed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,6 @@ BOT_TOKEN=
 # Client application ID generated on the Discord Developer Dashboard.
 APPLICATION_ID=
 
-# Discord ID of the user to be orz'ed every midnight.
-ORZ_TARGET_USER_ID=
-
 # Email inductees use for private queries to the Induction committee.
 INDUCTION_EMAIL=
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -43,10 +43,6 @@ export const ENV_SPEC = {
     desc: "Client application ID generated on the Discord Developer Dashboard.",
   }),
 
-  ORZ_TARGET_USER_ID: userIdValidator({
-    desc: "Discord ID of the user to be orz'ed every midnight.",
-  }),
-
   INDUCTION_EMAIL: envalid.email({
     desc: "Email inductees use for private queries to the Induction committee.",
   }),

--- a/src/features/convenience/timestamp.command.ts
+++ b/src/features/convenience/timestamp.command.ts
@@ -20,6 +20,7 @@ import {
   Month,
   MONTH_NAMES,
   SystemDateClient,
+  UCLA_TIMEZONE,
   type IDateClient,
 } from "../../utils/date.utils";
 import { makeErrorEmbed } from "../../utils/errors.utils";
@@ -61,13 +62,11 @@ const STYLE_CHOICES: APIApplicationCommandOptionChoice<TimestampStylesString>[]
   ];
 
 class TimestampCommand extends SlashCommandHandler {
-  private static readonly UCLA_TIMEZONE = "America/Los_Angeles";
-
   public override readonly definition = new SlashCommandBuilder()
     .setName("timestamp")
     .setDescription(
       "Format a timestamp mention based on input date/time, in UCLA time " +
-      `(${TimestampCommand.UCLA_TIMEZONE}).`,
+      `(${UCLA_TIMEZONE}).`,
     )
     .addBooleanOption(input => input
       .setName("help")
@@ -174,7 +173,7 @@ class TimestampCommand extends SlashCommandHandler {
 
     const dateTime = this.dateClient.getDateTime(
       { year, month, day, hour, minute, second },
-      TimestampCommand.UCLA_TIMEZONE,
+      UCLA_TIMEZONE,
     );
 
     if (dateTime.invalidReason !== null) {
@@ -194,7 +193,7 @@ class TimestampCommand extends SlashCommandHandler {
       "automatically renders in every user's current timezone. You can also " +
       `do neat things like using the ${italic("relative time")} format style ` +
       "to render countdowns. This command in particular will treat input as " +
-      `UCLA time (${inlineCode(TimestampCommand.UCLA_TIMEZONE)}).`
+      `UCLA time (${inlineCode(UCLA_TIMEZONE)}).`
     );
 
     const syntaxOverview = (

--- a/src/models/orzee.model.ts
+++ b/src/models/orzee.model.ts
@@ -1,0 +1,21 @@
+import mongoose from "mongoose";
+
+import type { UnixSeconds, UserId } from "../types/branded.types";
+
+export type Orzee = {
+  userId: UserId;
+  chosen: UnixSeconds;
+};
+
+const orzeeSchema = new mongoose.Schema<Orzee>({
+  userId: { type: String, required: true, unique: true },
+  chosen: { type: Number },
+});
+
+// TODO: At the moment, this shares the same database with the induction stuff,
+// which is seasonal. We should have a way to separate seasonal stuff from
+// general stuff.
+export const OrzeeModel = mongoose.model(
+  "OrzeeSet",
+  orzeeSchema,
+);

--- a/src/services/orz.service.ts
+++ b/src/services/orz.service.ts
@@ -1,17 +1,30 @@
 import {
+  bold,
   userMention,
   type Guild,
   type GuildTextBasedChannel,
+  type Role,
 } from "discord.js";
-import { asBrandedNumber, type UnixSeconds } from "../types/branded.types";
+import _ from "lodash";
 
-import env from "../env";
+import { OrzeeModel } from "../models/orzee.model";
+import {
+  asBrandedNumber,
+  type UnixSeconds,
+  type UserId,
+} from "../types/branded.types";
+import { isNonEmptyArray } from "../types/generic.types";
+import { setDifference } from "../utils/data.utils";
 import {
   SystemDateClient,
   UCLA_TIMEZONE,
-  type IDateClient
+  type IDateClient,
 } from "../utils/date.utils";
-import { OFFICER_MEMES_CHANNEL_ID } from "../utils/snowflakes.utils";
+import { reactString } from "../utils/emojis.utils";
+import {
+  OFFICER_MEMES_CHANNEL_ID,
+  OFFICERS_ROLE_ID,
+} from "../utils/snowflakes.utils";
 import channelsService from "./channels.service";
 
 class OrzService {
@@ -24,7 +37,17 @@ class OrzService {
         `officer memes channel (ID ${OFFICER_MEMES_CHANNEL_ID}) is invalid: ` +
         `${officerMemes}`
       );
-      console.warn(errorMessage);
+      console.error(errorMessage);
+      await channelsService.sendDevError(errorMessage);
+      return;
+    }
+
+    const officersRole = await upe.roles.fetch(OFFICERS_ROLE_ID);
+    if (officersRole === null) {
+      const errorMessage = (
+        `failed to get officers role (ID: ${OFFICERS_ROLE_ID})`
+      );
+      console.error(errorMessage);
       await channelsService.sendDevError(errorMessage);
       return;
     }
@@ -33,7 +56,10 @@ class OrzService {
     const nextMidnight = this.getNextMidnight(now);
     const msecLeft = (nextMidnight - now) * 1000;
     // Schedule the first orz.
-    setTimeout(async () => await this.sendOrz(officerMemes), msecLeft);
+    setTimeout(
+      async () => await this.sendOrz(officerMemes, officersRole),
+      msecLeft,
+    );
   }
 
   private getNextMidnight(now: UnixSeconds): UnixSeconds {
@@ -47,23 +73,65 @@ class OrzService {
     return asBrandedNumber(nextMidnight.toSeconds());
   }
 
-  private async sendOrz(officerMemes: GuildTextBasedChannel): Promise<void> {
+  private async sendOrz(
+    officerMemes: GuildTextBasedChannel,
+    officersRole: Role,
+  ): Promise<void> {
     try {
-      await officerMemes.send(
-        `Daily ${userMention(env.ORZ_TARGET_USER_ID)} orz`,
-      );
+      const orzee = await this.getNextOrzee(officersRole);
+      const message = await officerMemes.send(this.formatOrzMessage(orzee));
+      await reactString(message, "orz");
     }
     // This callback is outside of our standard execution pipeline, so manually
     // suppress exceptions to prevent bringing down the bot.
     catch (error) {
-      console.error("failed to send daily orz:", error);
+      console.error("failed to complete daily orz:", error);
       if (error instanceof Error) {
         await channelsService.sendDevError(error);
       }
     }
     // Schedule next orz.
     const ONE_DAY_MSEC = 3600 * 24 * 1000;
-    setTimeout(async () => this.sendOrz(officerMemes), ONE_DAY_MSEC);
+    setTimeout(
+      async () => this.sendOrz(officerMemes, officersRole),
+      ONE_DAY_MSEC,
+    );
+  }
+
+  private async getNextOrzee(officersRole: Role): Promise<UserId> {
+    const alreadyOrzed = await OrzeeModel.find();
+    // "whitelist" is all officers. "blacklist" is officers that have already
+    // been orzed. We want to choose from officers that haven't been orzed yet.
+    const blacklist = new Set(alreadyOrzed.map(orzee => orzee.userId));
+    const whitelist = new Set(
+      officersRole.members.map((_, userId) => userId as UserId),
+    );
+    const candidates = Array.from(setDifference(whitelist, blacklist));
+
+    if (isNonEmptyArray(candidates)) {
+      const orzee = _.sample(candidates);
+      await this.blacklistOrzee(orzee);
+      return orzee;
+    }
+
+    // Everyone's been orzed. Reset the orzee set.
+    await OrzeeModel.deleteMany();
+    const orzee = _.sample(Array.from(whitelist));
+    if (orzee === undefined) {
+      throw new Error("no officers found to orz");
+    }
+    await this.blacklistOrzee(orzee);
+    return orzee;
+  }
+
+  private async blacklistOrzee(userId: UserId): Promise<void> {
+    await OrzeeModel.create({ userId, chosen: this.dateClient.getNow() });
+  }
+
+  private formatOrzMessage(orzee: UserId): string {
+    return (
+      `${userMention(orzee)}, you've been chosen for the daily ${bold("orz")}!`
+    );
   }
 }
 

--- a/src/types/branded.types.ts
+++ b/src/types/branded.types.ts
@@ -12,6 +12,28 @@ export type Branded<T, B> = T & Brand<B>;
 /** Extract the brand tag of a branded type. */
 export type BrandOf<T> = T extends Brand<infer Tag> ? Tag : never;
 
+/**
+ * Convenience function for asserting that `value` is some `number`-derived
+ * branded type. Note that no check is done besides just checking that `value`
+ * is a `number`, so this is as type-safe as blindly asserting `as BrandedType`
+ * to an expression. Use with care.
+ */
+export function isBrandedNumber<T extends number>(
+  value: unknown,
+): value is T {
+  return typeof value === "number";
+}
+
+/**
+ * Convenience function for casting `value` to some `number`-derived branded
+ * type.
+ */
+export function asBrandedNumber<T extends number>(
+  value: unknown,
+): T {
+  return value as T;
+}
+
 /** Represents a filesystem path. */
 export type Path = Branded<string, "Path">;
 

--- a/src/utils/data.utils.ts
+++ b/src/utils/data.utils.ts
@@ -136,3 +136,18 @@ export class WritableMemoryStream extends Writable {
     return this.finished ? Buffer.concat(this.chunks) : this.finishPromise;
   }
 }
+
+/**
+ * Compute the set difference `lhs \ rhs`. This is provided because
+ * `Set.prototype.difference` is a new feature in Node.js and not yet widely
+ * supported.
+ */
+export function setDifference<T>(lhs: Set<T>, rhs: Set<T>): Set<T> {
+  const result = new Set<T>();
+  for (const element of lhs) {
+    if (!rhs.has(element)) {
+      result.add(element);
+    }
+  }
+  return result;
+}

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -1,9 +1,11 @@
 import { DateTime, type DateObjectUnits } from "luxon";
-import type { UnixSeconds } from "../types/branded.types";
+
+import { isBrandedNumber, type UnixSeconds } from "../types/branded.types";
 
 export interface IDateClient {
   getNow(): UnixSeconds;
   getDate(seconds: UnixSeconds): Date;
+  getDateTime(seconds: UnixSeconds, zone?: string): DateTime;
   getDateTime(units: DateObjectUnits, zone?: string): DateTime;
 }
 
@@ -16,8 +18,17 @@ export class SystemDateClient implements IDateClient {
     return new Date(seconds * 1000);
   }
 
-  public getDateTime(units: DateObjectUnits, zone?: string): DateTime {
-    return DateTime.fromObject(units, { zone });
+  public getDateTime(
+    arg: UnixSeconds | DateObjectUnits | Date,
+    zone?: string,
+  ): DateTime {
+    if (isBrandedNumber<UnixSeconds>(arg)) {
+      return DateTime.fromSeconds(arg);
+    }
+    if (arg instanceof Date) {
+      return DateTime.fromJSDate(arg);
+    }
+    return DateTime.fromObject(arg, { zone });
   }
 }
 
@@ -54,3 +65,9 @@ export type MonthName = keyof typeof Month;
 
 export const MONTH_NAMES = Object.values(Month)
   .filter(value => typeof value === "string") as MonthName[];
+
+export enum IanaTimeZone {
+  AmericaLosAngeles = "America/Los_Angeles",
+}
+
+export const UCLA_TIMEZONE = IanaTimeZone.AmericaLosAngeles;

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -23,10 +23,10 @@ export class SystemDateClient implements IDateClient {
     zone?: string,
   ): DateTime {
     if (isBrandedNumber<UnixSeconds>(arg)) {
-      return DateTime.fromSeconds(arg);
+      return DateTime.fromSeconds(arg, { zone });
     }
     if (arg instanceof Date) {
-      return DateTime.fromJSDate(arg);
+      return DateTime.fromJSDate(arg, { zone });
     }
     return DateTime.fromObject(arg, { zone });
   }

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -1,3 +1,4 @@
+import type { Message } from "discord.js";
 import type { Branded } from "../types/branded.types";
 
 export type BuiltinEmoji = Branded<`:${string}:`, "BuiltinEmoji">;
@@ -40,3 +41,27 @@ export const EMOJI_FIRST_PLACE = ":first_place:" as BuiltinEmoji;
 export const EMOJI_SECOND_PLACE = ":second_place:" as BuiltinEmoji;
 export const EMOJI_THIRD_PLACE = ":third_place:" as BuiltinEmoji;
 export const EMOJI_MEDAL = ":medal:" as BuiltinEmoji;
+
+export enum LetterReactionEmoji {
+  // TODO: Add all letters and also make an enum for numbers.
+  O = "🇴",
+  R = "🇷",
+  Z = "🇿",
+}
+
+export async function reactString(
+  message: Message,
+  sequence: string,
+): Promise<void> {
+  for (const character of sequence.toUpperCase()) {
+    const reactionEmoji = LetterReactionEmoji[
+      character as keyof typeof LetterReactionEmoji
+    ];
+    if (reactionEmoji === undefined) {
+      console.warn(`invalid letter to try and react with: ${character}`);
+    }
+    else {
+      await message.react(reactionEmoji);
+    }
+  }
+}


### PR DESCRIPTION
Upgrade of #15. Two main changes:
1. Made the notion of "midnight" timezone-aware. In #15, it would actually use UTC, so orzes were being sent at 5pm every day UCLA time. Now, orzes should be sent at midnights UCLA time.
2. Instead of orzing the same person every day, randomly choose an `@Officers` to orz. Furthermore, a persistent blacklist is maintained such that all officers are orzed before a reset happens and officers can be orzed again. That is, the officer chosen to be orzed uses the algorithm:

```
blacklist := { UIDs stored so far }
whitelist := { UIDs of the Officers role }
candidates := whitelist \ blacklist
if candidates is non-empty:
    orzee := random_sample(candidates)
    add orzee to blacklist
    return orzee
else
    clear blacklist
    orzee := random_sample(whitelist)
    add orzee to blacklist
    return orzee
endif
```