### PR TITLE
feat: add framework for text (prefix) commands

### DIFF
--- a/src/abc/command.abc.ts
+++ b/src/abc/command.abc.ts
@@ -12,7 +12,7 @@ import {
   Privilege,
 } from "../middleware/privilege.middleware";
 import channelsService from "../services/channels.service";
-import { makeErrorEmbed } from "../utils/errors.utils";
+import { assertErrorThrown, makeErrorEmbed } from "../utils/errors.utils";
 import type { SlashCommandCheck, SlashCommandCheckDetails } from "./check.abc";
 
 export abstract class SlashCommandHandler {
@@ -192,7 +192,7 @@ class CommandExecutionPipeline {
         this.passedChecks.push([check, details]);
       }
       catch (error) {
-        this.assertErrorThrown(error);
+        assertErrorThrown(error);
         try {
           await check.handleError(error, interaction);
         }
@@ -213,7 +213,7 @@ class CommandExecutionPipeline {
       return true;
     }
     catch (error) {
-      this.assertErrorThrown(error);
+      assertErrorThrown(error);
       try {
         await this.handler.handleError(error, interaction);
       }
@@ -235,7 +235,7 @@ class CommandExecutionPipeline {
         await filter.postHook(details, interaction);
       }
       catch (error) {
-        this.assertErrorThrown(error);
+        assertErrorThrown(error);
         try {
           await filter.handleError(error, interaction);
         }
@@ -254,7 +254,7 @@ class CommandExecutionPipeline {
       await this.handler.onComponent(interaction);
     }
     catch (error) {
-      this.assertErrorThrown(error);
+      assertErrorThrown(error);
       try {
         await this.handler.handleComponentError(error, interaction);
       }
@@ -275,7 +275,7 @@ class CommandExecutionPipeline {
       await this.handler.autocomplete(interaction);
     }
     catch (error) {
-      this.assertErrorThrown(error);
+      assertErrorThrown(error);
       try {
         await this.handler.handleAutocompleteError(error, interaction);
       }
@@ -286,13 +286,6 @@ class CommandExecutionPipeline {
         )
         throw error;
       }
-    }
-  }
-
-  private assertErrorThrown(thrown: unknown): asserts thrown is Error {
-    if (!(thrown instanceof Error)) {
-      console.error(`non-Error object thrown: ${thrown}`);
-      throw thrown;
     }
   }
 }

--- a/src/abc/text-command.abc.ts
+++ b/src/abc/text-command.abc.ts
@@ -1,0 +1,86 @@
+import type { Awaitable, Message } from "discord.js";
+
+import channelsService from "../services/channels.service";
+import { REACTION_BOT_ERROR } from "../utils/emojis.utils";
+import { assertErrorThrown } from "../utils/errors.utils";
+
+export abstract class TextCommandHandler<InGuild extends boolean = true> {
+  public static readonly COMMAND_PREFIX = "!";
+
+  /**
+   * Name used to uniquely identify & invoke this command.
+   *
+   * A command is invoked in a Discord text channel by prefixing the name with
+   * the `COMMAND_PREFIX`.
+   */
+  public abstract readonly name: string;
+
+  // TODO: Add support for checks like SlashCommandHandler has.
+
+  /** Pipeline execution engine to manage handler lifecycle. */
+  private readonly pipeline = new TextCommandExecutionPipeline<InGuild>(this)
+
+  /**
+   * ID to identify a handler class. Should be unique. Defaults to the command
+   * prefix followed by the command name e.g. `!command-name`.
+   */
+  public get id(): string {
+    return TextCommandHandler.COMMAND_PREFIX + this.name
+  }
+
+  /** Shorthand for formatting this handler's details, such as for logging. */
+  public get logName(): string {
+    return `${this.id} text command handler`
+  }
+
+  /** Main callback to execute when the text command is invoked. */
+  public abstract execute(
+    message: Message<InGuild>
+  ): Awaitable<any>;
+
+  /** Fallback callback for if the main callback throws an `Error`. */
+  public async handleError(
+    error: Error,
+    message: Message<InGuild>
+  ): Promise<any> {
+    console.error(`${error.name} in ${this.logName}:`);
+    console.error(error);
+    await channelsService.sendDevError(error, message);
+    await message.react(REACTION_BOT_ERROR);
+  }
+
+  /** Run full execution pipeline for a slash command invocation. */
+  public async dispatch(
+    message: Message<InGuild>
+  ): Promise<void> {
+    await this.pipeline.run(message)
+  }
+}
+
+class TextCommandExecutionPipeline<InGuild extends boolean = true> {
+  public constructor(private readonly handler: TextCommandHandler<InGuild>) { }
+
+  public async run(message: Message<InGuild>): Promise<void> {
+    await this.executeMain(message)
+  }
+
+  private async executeMain(message: Message<InGuild>): Promise<boolean> {
+    try {
+      await this.handler.execute(message);
+      return true;
+    }
+    catch (error) {
+      assertErrorThrown(error);
+      try {
+        await this.handler.handleError(error, message);
+      }
+      catch (error) {
+        console.error(
+          `Error handler of ${this.handler.logName} threw: ${error}`,
+        );
+        throw error;
+      }
+    }
+    return false;
+  }
+}

--- a/src/abc/text-command.abc.ts
+++ b/src/abc/text-command.abc.ts
@@ -39,9 +39,14 @@ export abstract class TextCommandHandler<
 
   /**
    * Transform the entire text following the command invocation into the
-   * properly typed argument vector.
+   * properly typed argument vector. Return `null` if there is an error in
+   * transformation. The callee is responsible for any user-facing response to
+   * acknowledge bad input.
    */
-  public abstract transformArguments(corpus: string): Awaitable<TArguments>;
+  public abstract transformArguments(
+    corpus: string,
+    message: Message<InGuild>,
+  ): Awaitable<TArguments | null>;
 
   /** Main callback to execute when the text command is invoked. */
   public abstract execute(

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -30,6 +30,7 @@ export class ClientManager {
     GatewayIntentBits.GuildPresences,
     GatewayIntentBits.GuildModeration,
     GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
   ] as const satisfies readonly GatewayIntentBits[];
 
   public static readonly INITIAL_LISTENERS = [

--- a/src/bot/listeners/message-create.listener.ts
+++ b/src/bot/listeners/message-create.listener.ts
@@ -30,9 +30,12 @@ class MessageCreateListener extends DiscordEventListener<Events.MessageCreate> {
     console.log(
       `[TRANSFORM] ${handler.id} by @${caller.username} in #${channel}`,
     );
-    let commandArgs: unknown[];
+    let commandArgs: unknown[] | null;
     try {
-      commandArgs = await handler.transformArguments(corpus);
+      commandArgs = await handler.transformArguments(corpus, message);
+      if (commandArgs === null) {
+        return;
+      }
     }
     catch (error) {
       console.error(

--- a/src/bot/listeners/message-create.listener.ts
+++ b/src/bot/listeners/message-create.listener.ts
@@ -1,0 +1,51 @@
+import { Events, Message } from "discord.js";
+
+import { DiscordEventListener } from "../../abc/listener.abc";
+import { TextCommandHandler } from "../../abc/text-command.abc";
+import { removePrefix } from "../../utils/data.utils";
+import {
+  REACTION_BOT_ERROR,
+  REACTION_UNKNOWN_TEXT_COMMAND,
+} from "../../utils/emojis.utils";
+import { textCommandLoader } from "../loaders";
+
+class MessageCreateListener extends DiscordEventListener<Events.MessageCreate> {
+  public override readonly event = Events.MessageCreate;
+
+  public override async execute(message: Message): Promise<void> {
+    const { content, channel, author: caller } = message;
+
+    if (!content.startsWith(TextCommandHandler.COMMAND_PREFIX)) {
+      return;
+    }
+
+    // TODO: Forward command args and/or implement argument lexing.
+    const [invocation, ..._commandArgs] = content.split(/\s+/);
+    const commandName = removePrefix(
+      invocation,
+      TextCommandHandler.COMMAND_PREFIX,
+    );
+
+    const handler = textCommandLoader.get(commandName);
+    if (handler === null) {
+      await message.react(REACTION_UNKNOWN_TEXT_COMMAND);
+      return;
+    }
+
+    console.log(
+      `[DISPATCH] ${handler.id} by @${caller.username} in #${channel}`,
+    );
+    try {
+      await handler.dispatch(message);
+    }
+    catch (error) {
+      console.error(
+        "[DISPATCH] Uncaught error in text command execution pipeline:",
+      );
+      console.error(error);
+      await message.react(REACTION_BOT_ERROR);
+    }
+  }
+}
+
+export default new MessageCreateListener();

--- a/src/bot/loaders.ts
+++ b/src/bot/loaders.ts
@@ -166,7 +166,9 @@ class ListenerLoader extends HandlerLoader<DiscordEventListener<any>> {
 
 export const listenerLoader = new ListenerLoader();
 
-class TextCommandLoader extends HandlerLoader<TextCommandHandler<boolean>> {
+class TextCommandLoader
+  extends HandlerLoader<TextCommandHandler<unknown[], boolean>> {
+
   public constructor() {
     super(TextCommandHandler);
   }

--- a/src/bot/loaders.ts
+++ b/src/bot/loaders.ts
@@ -5,6 +5,7 @@ import { Collection } from "discord.js";
 
 import { SlashCommandHandler } from "../abc/command.abc";
 import { DiscordEventListener } from "../abc/listener.abc";
+import { TextCommandHandler } from "../abc/text-command.abc";
 import type { Path } from "../types/branded.types";
 
 abstract class HandlerLoader<Handler> {
@@ -164,3 +165,20 @@ class ListenerLoader extends HandlerLoader<DiscordEventListener<any>> {
 }
 
 export const listenerLoader = new ListenerLoader();
+
+class TextCommandLoader extends HandlerLoader<TextCommandHandler<boolean>> {
+  public constructor() {
+    super(TextCommandHandler);
+  }
+
+  protected override getHandlerName(handler: TextCommandHandler): string {
+    return handler.name;
+  }
+
+  protected override isHandlerFile(path: Path): boolean {
+    return path.endsWith(".text-command.js")
+      || path.endsWith(".text-command.ts");
+  }
+}
+
+export const textCommandLoader = new TextCommandLoader();

--- a/src/features/dev/ping.text-command.ts
+++ b/src/features/dev/ping.text-command.ts
@@ -16,6 +16,10 @@ class PingTextCommand extends TextCommandHandler<string[]> {
       await message.reply("You said the nono string!");
       return null;
     }
+    // Edge case.
+    if (tokens.length === 1 && tokens[0] === "") {
+      return [];
+    }
     return tokens;
   }
 

--- a/src/features/dev/ping.text-command.ts
+++ b/src/features/dev/ping.text-command.ts
@@ -7,8 +7,16 @@ import { DEVELOPER_ROLE_ID } from "../../utils/snowflakes.utils";
 class PingTextCommand extends TextCommandHandler<string[]> {
   public override readonly name = "ping";
 
-  public override transformArguments(corpus: string): string[] {
-    return corpus.split(/\s+/);
+  public override async transformArguments(
+    corpus: string,
+    message: Message,
+  ): Promise<string[] | null> {
+    const tokens = corpus.split(/\s+/);
+    if (tokens.some(token => token === "NONO-STRING")) {
+      await message.reply("You said the nono string!");
+      return null;
+    }
+    return tokens;
   }
 
   public override async execute(

--- a/src/features/dev/ping.text-command.ts
+++ b/src/features/dev/ping.text-command.ts
@@ -1,0 +1,47 @@
+import { bold, codeBlock, type Client, type Message } from "discord.js";
+
+import { TextCommandHandler } from "../../abc/text-command.abc";
+import { REACTION_UNAUTHORIZED_TEXT_COMMAND } from "../../utils/emojis.utils";
+import { DEVELOPER_ROLE_ID } from "../../utils/snowflakes.utils";
+
+class PingTextCommand extends TextCommandHandler<string[]> {
+  public override readonly name = "ping";
+
+  public override transformArguments(corpus: string): string[] {
+    return corpus.split(/\s+/);
+  }
+
+  public override async execute(
+    message: Message,
+    commandArgs: string[],
+  ): Promise<void> {
+    // TODO: When checks are added to the framework, move this access control up
+    // into that layer.
+    if (
+      message.member === null ||
+      !message.member.roles.cache.has(DEVELOPER_ROLE_ID)
+    ) {
+      await message.react(REACTION_UNAUTHORIZED_TEXT_COMMAND);
+      return;
+    }
+
+    let content = `Hello there! ${this.formatLatency(message.client)}`;
+
+    if (commandArgs.length > 0) {
+      content += `\nCalled with ${commandArgs.length} arguments:\n`;
+      content += codeBlock(commandArgs.join("\n"));
+    }
+
+    await message.reply(content);
+  }
+
+  private formatLatency(client: Client): string {
+    const latency = client.ws.ping;
+    if (latency === -1) {
+      return "Latency: (still being calculated...)";
+    }
+    return `Latency: ${bold(latency.toString())} ms`;
+  }
+}
+
+export default new PingTextCommand();

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ async function main(): Promise<void> {
   const clientManager = new ClientManager({
     commandsRoot: PROJECT_FEATURES_ROOT,
     listenersRoot: PROJECT_FEATURES_ROOT,
+    textCommandsRoot: PROJECT_FEATURES_ROOT,
     databaseConnectionString: env.DB_CONNECTION_STRING,
     databaseName: env.DB_NAME,
     botToken: env.BOT_TOKEN,

--- a/src/utils/data.utils.ts
+++ b/src/utils/data.utils.ts
@@ -151,3 +151,11 @@ export function setDifference<T>(lhs: Set<T>, rhs: Set<T>): Set<T> {
   }
   return result;
 }
+
+/** Imitation of Python's `str.removeprefix(original, prefix)`. */
+export function removePrefix(original: string, prefix: string): string {
+  if (original.startsWith(prefix)) {
+    return original.slice(prefix.length);
+  }
+  return original;
+}

--- a/src/utils/data.utils.ts
+++ b/src/utils/data.utils.ts
@@ -159,3 +159,8 @@ export function removePrefix(original: string, prefix: string): string {
   }
   return original;
 }
+
+/** Imitation of Python's `str.isspace(s)`. */
+export function isSpace(s: string): boolean {
+  return /^\s*$/.test(s);
+}

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -42,12 +42,21 @@ export const EMOJI_SECOND_PLACE = ":second_place:" as BuiltinEmoji;
 export const EMOJI_THIRD_PLACE = ":third_place:" as BuiltinEmoji;
 export const EMOJI_MEDAL = ":medal:" as BuiltinEmoji;
 
+// NOTE: We distinguish reaction emojis from "built-in emojis" because we need
+// to pass in the actual Unicode emoji string to reaction APIs instead of the
+// colon form.
+export type UnicodeReactionEmoji = Branded<string, "RawReactionEmoji">;
+
 export enum LetterReactionEmoji {
   // TODO: Add all letters and also make an enum for numbers.
   O = "🇴",
   R = "🇷",
   Z = "🇿",
 }
+
+export type ReactionEmoji = UnicodeReactionEmoji | LetterReactionEmoji;
+
+export const REACTION_BOT_ERROR = "😵" as UnicodeReactionEmoji;
 
 export async function reactString(
   message: Message,

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -58,6 +58,7 @@ export type ReactionEmoji = UnicodeReactionEmoji | LetterReactionEmoji;
 
 export const REACTION_BOT_ERROR = "😵" as UnicodeReactionEmoji;
 export const REACTION_UNKNOWN_TEXT_COMMAND = "❓" as UnicodeReactionEmoji;
+export const REACTION_UNAUTHORIZED_TEXT_COMMAND = "⛔" as UnicodeReactionEmoji;
 
 export async function reactString(
   message: Message,

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -57,6 +57,7 @@ export enum LetterReactionEmoji {
 export type ReactionEmoji = UnicodeReactionEmoji | LetterReactionEmoji;
 
 export const REACTION_BOT_ERROR = "😵" as UnicodeReactionEmoji;
+export const REACTION_UNKNOWN_TEXT_COMMAND = "❓" as UnicodeReactionEmoji;
 
 export async function reactString(
   message: Message,

--- a/src/utils/errors.utils.ts
+++ b/src/utils/errors.utils.ts
@@ -64,3 +64,10 @@ export function isMongoDuplicateKeyError(error: unknown)
   : error is MongoErrorWithCode<11000> {
   return error instanceof MongoError && error.code === 11000;
 }
+
+export function assertErrorThrown(thrown: unknown): asserts thrown is Error {
+  if (!(thrown instanceof Error)) {
+    console.error(`non-Error object thrown: ${thrown}`);
+    throw thrown;
+  }
+}


### PR DESCRIPTION
Motivation: https://github.com/vinlin24/upe-discord-bot/pull/17#pullrequestreview-2969432400

Overview
* Add `TextCommandHandler` ABC. Command prefix is hard-coded to `!` for now.
* Developers implement handlers in `.text-command.ts` files, implementing:
  * Command name.
  * A callback for transforming text after the command invocation into some argument vector of the developer's design (argument type is a type parameter to the handler class).
  * The `execute` callback, similar to event listeners and slash command handlers.
* Add a simple `!ping` text command handler to sanity check this new framework.

> [!WARNING]
>
> The bot's privilege has been elevated to support this feature: the bot now initializes with the `MessageContent` privileged gateway intent.