### PR TITLE
feat: provide user ID for new member join flow

### DIFF
--- a/src/features/convenience/whoami.command.ts
+++ b/src/features/convenience/whoami.command.ts
@@ -1,7 +1,6 @@
 import {
-  codeBlock,
   SlashCommandBuilder,
-  type ChatInputCommandInteraction
+  type ChatInputCommandInteraction,
 } from "discord.js";
 
 import { SlashCommandHandler } from "../../abc/command.abc";
@@ -9,10 +8,10 @@ import { SlashCommandHandler } from "../../abc/command.abc";
 class WhoamiCommand extends SlashCommandHandler {
   public override readonly definition = new SlashCommandBuilder()
     .setName("whoami")
-    .setDescription("Check what your Discord username is.")
+    .setDescription("Get your Discord ID")
     .addUserOption(input => input
       .setName("user")
-      .setDescription("User whose username to check. Defaults to yourself.")
+      .setDescription("User whose ID to check. Defaults to yourself.")
     )
     .toJSON();
 
@@ -21,7 +20,7 @@ class WhoamiCommand extends SlashCommandHandler {
   ): Promise<void> {
     const targetUser = interaction.options.getUser("user") ?? interaction.user;
     await interaction.reply({
-      content: codeBlock(targetUser.username),
+      content: targetUser.id,
       ephemeral: true,
     });
   }

--- a/src/features/inductee-role/member-join.listener.ts
+++ b/src/features/inductee-role/member-join.listener.ts
@@ -1,0 +1,32 @@
+import { Events, type GuildMember } from "discord.js";
+
+import { DiscordEventListener } from "../../abc/listener.abc";
+import type { UserId } from "../../types/branded.types";
+import { quietHyperlink } from "../../utils/formatting.utils";
+import { UPE_WEBSITE } from "../../utils/upe.utils";
+
+class MemberJoinListener
+  extends DiscordEventListener<Events.GuildMemberAdd> {
+
+  public override readonly event = Events.GuildMemberAdd;
+
+  public static readonly WELCOME_MESSAGE = (
+    "Welcome to the Discord server for Upsilon Pi Epsilon at UCLA! " +
+    "To learn more about us, visit our " +
+    quietHyperlink("website", UPE_WEBSITE) + ".\n\n" +
+    // TODO: Can make it so that this part of the welcome message & user ID
+    // sending only activates based on some flag (either config or runtime).
+    "If you're an inductee, this is your user ID to paste back into the " +
+    "pre-induction questionnaire form:"
+  );
+
+  public override async execute(member: GuildMember): Promise<boolean> {
+    const callerId = member.id as UserId;
+    const dmChannel = member.dmChannel ?? await member.createDM();
+    await dmChannel.send(MemberJoinListener.WELCOME_MESSAGE);
+    await dmChannel.send(callerId);
+    return true;
+  }
+}
+
+export default new MemberJoinListener();


### PR DESCRIPTION
Part 1/2 of our redesign to reduce friction for inductees joining the Discord server (and for ourselves).

## Motivation

Our pre-induction questionnaire form starting this season will ask for user ID instead of username since that makes automation a lot easier and reduces the possible error cases for when a username doesn't successfully map to a Discord user (i.e. was it because the username was wrong, was a display name instead, was correct but they're not in the server, etc.?—we are constantly reminded that [many people do not follow directions](https://www.reddit.com/r/ucla/comments/dp1dau/smallberg_didnt_have_to_go_this_hard/)). The new envisioned flow will be:

1. Inductee fills out the pre-induction questionnaire form and sees the field for Discord ID. The description includes an invite link to the UPE server.
2. The inductee joins/redirects to the server. If they are new, they are sent a DM from the bot with a welcome message and their user ID. If they were already in the server, they run `/whoami` to retrieve their user ID.
3. The inductee copies the user ID and pastes it back into the form.

This flow should realistically be _not_ a problem for a bunch of CS and CS-adjacent members.

## Summary

This PR implements the user-facing part of our redesign. It does two things:

- Overhauls `/whoami` (introduced in 5b84c3d20dc58b7e7fc0475f427877a9ebbc32ea) to return user ID instead of username. It also makes it more mobile-friendly, no longer wrapping the ID in a code fence since copying on mobile would copy the backticks with it.
- Adds a new member join listener that DMs a welcome message to _all_ new members, and also sends the user ID so inductees can paste that back into the orientation form.

Continuation is needed to update the parsing of the questionnaire responses sheet to expect user IDs instead of usernames now, and thus all code referencing the parsed sheets data also needs to index it by ID instead of username.