### PR TITLE
feat!: disable bit-byte leaderboard/events cmds

### DIFF
--- a/src/abc/command.abc.ts
+++ b/src/abc/command.abc.ts
@@ -20,6 +20,12 @@ export abstract class SlashCommandHandler {
   public abstract readonly definition
     : RESTPostAPIChatInputApplicationCommandsJSONBody;
 
+  /**
+   * Set to false if we want to keep the definition around for whatever reason
+   * but currently do not want to expose it as an invocable command.
+   */
+  public readonly shouldRegister: boolean = true;
+
   /** Checks that must pass before the main command handler can run. */
   public checks: SlashCommandCheck[] = [];
 

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -50,7 +50,9 @@ export class ClientManager {
     await this.loadCommands();
 
     const handlers = Array.from(commandLoader.getAll().values());
-    const commandsJson = handlers.map(handler => handler.definition);
+    const commandsJson = handlers
+      .filter(handler => handler.shouldRegister)
+      .map(handler => handler.definition);
 
     const { botToken, applicationId } = this.options;
     const rest = new REST().setToken(botToken);

--- a/src/features/bit-byte/leaderboard.command.ts
+++ b/src/features/bit-byte/leaderboard.command.ts
@@ -28,7 +28,10 @@ type LeaderboardEntry = {
   points: number;
 };
 
+/** @deprecated As of F25, bit-byte no longer has a leaderboard/prize system. */
 class LeaderboardCommand extends SlashCommandHandler {
+  public override readonly shouldRegister = false;
+
   public override readonly definition = new SlashCommandBuilder()
     .setName("leaderboardbitbyte")
     .setDescription("Are ya winnin'?")

--- a/src/features/bit-byte/submit-event.command.ts
+++ b/src/features/bit-byte/submit-event.command.ts
@@ -32,7 +32,10 @@ type ResolvedCommandOptions = {
   picture: Attachment;
 };
 
+/** @deprecated As of F25, bit-byte no longer has a leaderboard/prize system. */
 class SubmitEventCommand extends SlashCommandHandler {
+  public override readonly shouldRegister = false;
+
   public override readonly definition = new SlashCommandBuilder()
     .setName("submitbitbyte")
     .setDescription("Get points for events with your bits!")

--- a/src/features/bit-byte/submit-jeopardy.command.ts
+++ b/src/features/bit-byte/submit-jeopardy.command.ts
@@ -16,7 +16,10 @@ import {
 import { BitByteGroupModel } from "../../models/bit-byte.model";
 import type { RoleId } from "../../types/branded.types";
 
+/** @deprecated As of F25, bit-byte no longer has a leaderboard/prize system. */
 class SubmitJeopardyCommand extends SlashCommandHandler {
+  public override readonly shouldRegister = false;
+
   public override readonly definition = new SlashCommandBuilder()
     .setName("jeopardybitbyte")
     .setDescription("Submit the jeopardy event for a bit-byte group.")

--- a/src/features/bit-byte/view-events.command.ts
+++ b/src/features/bit-byte/view-events.command.ts
@@ -18,7 +18,10 @@ import { isNonEmptyArray } from "../../types/generic.types";
 import { EmbedPagesManager } from "../../utils/components.utils";
 import { SystemDateClient, type IDateClient } from "../../utils/date.utils";
 
+/** @deprecated As of F25, bit-byte no longer has a leaderboard/prize system. */
 class ViewEventsCommand extends SlashCommandHandler {
+  public override readonly shouldRegister = false;
+
   public override readonly definition = new SlashCommandBuilder()
     .setName("eventsbitbyte")
     .setDescription("Look through any bit-byte group's submitted events.")


### PR DESCRIPTION
## Motivation

As of F25 induction season, the bit-byte program no longer has a leaderboard/prize system.

## Summary

1. Added a new property to the `SlashCommandHandler` ABC defining whether the handler definition should be deployed (and thus be invocable on Discord). This defaults to `true`; setting to `false` is to express that we might still want this definition around for whatever reason but just don't deploy it for now.
2. Deprecate and disable command registration for the `/leaderboardbitbyte`, `/submitbitbyte`, `/jeopardybitbyte`, and `/eventsbitbyte` commands.