### PR TITLE
feat: add active/dropped status to inductee info

### DIFF
--- a/src/features/convenience/inductee-lookup.command.ts
+++ b/src/features/convenience/inductee-lookup.command.ts
@@ -1,5 +1,6 @@
 import {
   bold,
+  codeBlock,
   Collection,
   EmbedBuilder,
   inlineCode,
@@ -21,6 +22,7 @@ import {
 } from "../../middleware/privilege.middleware";
 import bitByteService from "../../services/bit-byte.service";
 import sheetsService, {
+  InducteeStatus,
   type InducteeData,
 } from "../../services/inductee-sheets.service";
 import type { UserId } from "../../types/branded.types";
@@ -121,7 +123,9 @@ class InducteeLookupCommand extends SlashCommandHandler {
     inducteeMember: GuildMember | null,
     inducteeData: InducteeData,
   ): Promise<EmbedBuilder> {
-    const { legalName, preferredName, preferredEmail, major } = inducteeData;
+    const {
+      status, legalName, preferredName, preferredEmail, major,
+    } = inducteeData;
 
     const lines = [
       `${bold("Name:")} ${legalName}`,
@@ -139,6 +143,13 @@ class InducteeLookupCommand extends SlashCommandHandler {
     else {
       lines.push(`${bold("Bit-Byte:")} ${roleMention(groupRole.id)}`);
     }
+
+    // Cool green banner if active, red if otherwise.
+    const statusBanner = bold("Induction Status:") + codeBlock(
+      "diff",
+      (status === InducteeStatus.Active ? "+" : "-") + status,
+    );
+    lines.push(statusBanner);
 
     const mention = inducteeMember === null
       ? (inlineCode(userMention(inducteeData.discordId)) + " (not in server)")

--- a/src/features/convenience/inductee-lookup.command.ts
+++ b/src/features/convenience/inductee-lookup.command.ts
@@ -1,6 +1,5 @@
 import {
   bold,
-  codeBlock,
   Collection,
   EmbedBuilder,
   inlineCode,
@@ -26,6 +25,7 @@ import sheetsService, {
   type InducteeData,
 } from "../../services/inductee-sheets.service";
 import type { UserId } from "../../types/branded.types";
+import { EMOJI_CHECK, EMOJI_WARNING } from "../../utils/emojis.utils";
 import { makeErrorEmbed } from "../../utils/errors.utils";
 import { toBulletedList } from "../../utils/formatting.utils";
 
@@ -144,18 +144,17 @@ class InducteeLookupCommand extends SlashCommandHandler {
       lines.push(`${bold("Bit-Byte:")} ${roleMention(groupRole.id)}`);
     }
 
-    // Cool green banner if active, red if otherwise.
-    const statusBanner = bold("Induction Status:") + codeBlock(
-      "diff",
-      (status === InducteeStatus.Active ? "+" : "-") + status,
-    );
-    lines.push(statusBanner);
-
     const mention = inducteeMember === null
       ? (inlineCode(userMention(inducteeData.discordId)) + " (not in server)")
       : userMention(inducteeMember.id);
 
-    const description = mention + "\n" + toBulletedList(lines.filter(Boolean));
+    const statusText = `${status.toUpperCase()} ` + (
+      status === InducteeStatus.Active
+        ? EMOJI_CHECK
+        : EMOJI_WARNING
+    );
+    const header = `${mention} ${bold(`(${statusText})`)}`;
+    const description = header + "\n" + toBulletedList(lines.filter(Boolean));
 
     return new EmbedBuilder()
       .setColor(groupRole?.color ?? null)

--- a/src/features/inductee-role/inductee-join.listener.ts
+++ b/src/features/inductee-role/inductee-join.listener.ts
@@ -10,6 +10,7 @@ import {
 import { DiscordEventListener } from "../../abc/listener.abc";
 import channelsService from "../../services/channels.service";
 import inducteeSheetsService, {
+  InducteeStatus,
   type InducteeData,
 } from "../../services/inductee-sheets.service";
 import type { UserId } from "../../types/branded.types";
@@ -24,9 +25,15 @@ export class InducteeJoinListener
     // TODO: Proper logging.
     console.log(`User ${member.user.username} joined.`);
 
-    let inducteeData = await inducteeSheetsService.getData(member.id as UserId);
+    const inducteeData = await inducteeSheetsService.getData(
+      member.id as UserId,
+    );
 
-    if (inducteeData === null) {
+    // Ignore members that aren't inductees or were inductees but got dropped.
+    if (
+      inducteeData === null ||
+      inducteeData.status !== InducteeStatus.Active
+    ) {
       return false;
     }
 

--- a/src/features/inductee-role/prune-inductees.command.ts
+++ b/src/features/inductee-role/prune-inductees.command.ts
@@ -23,7 +23,13 @@ import { type UserId } from "../../types/branded.types";
 import { toBulletedList } from "../../utils/formatting.utils";
 import { INDUCTEES_ROLE_ID } from "../../utils/snowflakes.utils";
 
+/**
+ * @deprecated As of F25, bit-byte is no longer tied to induction, so this
+ * command doesn't make much sense anymore.
+ */
 export class PruneInducteesCommand extends SlashCommandHandler {
+  public override readonly shouldRegister = false;
+
   public override readonly definition = new SlashCommandBuilder()
     .setName("pruneinductees")
     .setDescription(

--- a/src/features/trolling/lp.command.ts
+++ b/src/features/trolling/lp.command.ts
@@ -22,7 +22,7 @@ const LP_MAP = new Map<string, UrlString>([
   ["Earn Trust", "https://youtu.be/SD5GB_6pGOg" as UrlString],
   ["Dive Deep", "https://youtu.be/trHT6thsoZ0" as UrlString],
   ["Have Backbone; Disagree and Commit", "https://youtu.be/BtjBkf8qDW4" as UrlString],
-  ["Deliver Result", "https://youtu.be/bgOyaYq8UNI" as UrlString],
+  ["Deliver Results", "https://youtu.be/bgOyaYq8UNI" as UrlString],
   ["Strive to be Earth’s Best Employer", "https://youtu.be/i8iRGy8ynTo" as UrlString],
   ["Success and Scale Bring Broad Responsibility", "https://youtu.be/6UbFkMF4Q-U" as UrlString],
 ]);

--- a/src/services/inductee-sheets.service.ts
+++ b/src/services/inductee-sheets.service.ts
@@ -23,18 +23,17 @@ export enum UpeMajor {
 }
 
 enum RegistryColumn {
-  Status = 0,
-  PreferredEmail,
+  PreferredEmail = 0,
   LegalFirst,
   LegalLast,
   PreferredFirst,
   PreferredLast,
   DiscordId,
   Major,
+  Status,
 }
 
 const RegistrySchema = z.tuple([
-  z.nativeEnum(InducteeStatus), // Status
   z.string().trim(),            // PreferredEmail
   z.string().trim(),            // LegalFirst
   z.string().trim(),            // LegalLast
@@ -42,6 +41,7 @@ const RegistrySchema = z.tuple([
   z.string().trim(),            // PreferredLast
   z.string().trim(),            // DiscordId
   z.nativeEnum(UpeMajor),       // Major
+  z.nativeEnum(InducteeStatus), // Status
 ]).rest(z.any());
 
 type RegistryRow = z.infer<typeof RegistrySchema>;

--- a/src/services/inductee-sheets.service.ts
+++ b/src/services/inductee-sheets.service.ts
@@ -6,8 +6,13 @@ import env from "../env";
 import type { Seconds, UserId } from "../types/branded.types";
 import { SystemDateClient } from "../utils/date.utils";
 
-// NOTE: The value side of the enum is the "full name" of the major used in thes
-// Google Forms/Sheets.
+export enum InducteeStatus {
+  Active = "Active",
+  Dropped = "Dropped",
+}
+
+// NOTE: The value side of the enum is the "full name" of the major used in
+// these Google Forms/Sheets.
 export enum UpeMajor {
   Cs = "Computer Science",
   Cse = "Computer Science & Engineering",
@@ -18,7 +23,8 @@ export enum UpeMajor {
 }
 
 enum RegistryColumn {
-  PreferredEmail = 0,
+  Status = 0,
+  PreferredEmail,
   LegalFirst,
   LegalLast,
   PreferredFirst,
@@ -28,19 +34,21 @@ enum RegistryColumn {
 }
 
 const RegistrySchema = z.tuple([
-  z.string().trim(),      // PreferredEmail
-  z.string().trim(),      // LegalFirst
-  z.string().trim(),      // LegalLast
-  z.string().trim(),      // PreferredFirst
-  z.string().trim(),      // PreferredLast
-  z.string().trim(),      // DiscordId
-  z.nativeEnum(UpeMajor), // Major
+  z.nativeEnum(InducteeStatus), // Status
+  z.string().trim(),            // PreferredEmail
+  z.string().trim(),            // LegalFirst
+  z.string().trim(),            // LegalLast
+  z.string().trim(),            // PreferredFirst
+  z.string().trim(),            // PreferredLast
+  z.string().trim(),            // DiscordId
+  z.nativeEnum(UpeMajor),       // Major
 ]).rest(z.any());
 
 type RegistryRow = z.infer<typeof RegistrySchema>;
 
 /** The DTO passed around outside of this service, to represent an inductee. */
 export type InducteeData = {
+  status: InducteeStatus;
   preferredEmail: string;
   legalName: string;
   preferredName?: string;
@@ -68,12 +76,13 @@ export class InducteeSheetsService extends RowWiseSheetsService<
   }
 
   protected override acceptRow(rowIndex: number, _row: string[]): boolean {
-    return rowIndex >= 3; // Skip two comment rows & header rows.
+    return rowIndex >= 3; // Skip comment row & two header rows.
   }
 
   protected override transformRow(
     validatedRow: RegistryRow,
   ): InducteeData {
+    const status = validatedRow[RegistryColumn.Status];
     const legalFirst = validatedRow[RegistryColumn.LegalFirst];
     const legalLast = validatedRow[RegistryColumn.LegalLast];
 
@@ -88,6 +97,7 @@ export class InducteeSheetsService extends RowWiseSheetsService<
       = validatedRow[RegistryColumn.PreferredLast] || legalLast;
 
     return {
+      status,
       preferredEmail: validatedRow[RegistryColumn.PreferredEmail],
       legalName: `${legalFirst} ${legalLast}`,
       preferredName: `${preferredFirst} ${preferredLast}`.trim() || undefined,


### PR DESCRIPTION
## Motivation

On the Google Sheets side, it's a lot easier to have all inductee info (copied from the pre-induction questionnaire responses) in one place and then just use a dropdown chip to change an inductee's status in/out of "Active" and "Dropped" instead of maintaining separate lists or just deleting rows forever.

## Summary

The inductee sheets service has been updated to reflect the new status column on the inductee info sheets. That column is assumed to have non-null values of either:
- `Active`
- `Dropped`

An inductee is considered **active** if their value in that column is `Active`.

The inductee join listener and `/syncinductees` command (#24) have been updated to only recognize **active** inductee users. The `/inductee` lookup command still returns data for dropped inductees but now clearly distinguishes between active and dropped ones in the returned embed.