### PR TITLE
fix: populate cache during commands fetch

### DIFF
--- a/src/features/dev/commands.command.ts
+++ b/src/features/dev/commands.command.ts
@@ -29,9 +29,10 @@ class CommandsCommand extends SlashCommandHandler {
     interaction: ChatInputCommandInteraction,
   ): Promise<void> {
     const { client } = interaction;
+    const commands = await client.application.commands.fetch();
 
     const entries: string[] = [];
-    for (const apiCommand of client.application.commands.cache.values()) {
+    for (const apiCommand of commands.values()) {
       const { id, name, description } = apiCommand;
       const mention = chatInputApplicationCommandMention(name, id);
       entries.push(`${mention}: ${inlineCode(mention)}\n${quote(description)}`);


### PR DESCRIPTION
I get the following error on a `/commands` evocation:

```
TypeError: Cannot read properties of undefined (reading 'toJSON')
    at changeFooter (/root/upe-discord-bot/node_modules/@devraelfreeze/discordjs-pagination/dist/pagination/pagination.js:67:33)
    at pagination (/root/upe-discord-bot/node_modules/@devraelfreeze/discordjs-pagination/dist/pagination/pagination.js:84:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async CommandsCommand.execute (/root/upe-discord-bot/dist/features/dev/commands.command.js:25:9)
    at async CommandExecutionPipeline.executeMain (/root/upe-discord-bot/dist/abc/command.abc.js:114:13)
    at async CommandExecutionPipeline.run (/root/upe-discord-bot/dist/abc/command.abc.js:73:16)
    at async CommandsCommand.dispatch (/root/upe-discord-bot/dist/abc/command.abc.js:45:9)
    at async InteractionDispatchListener.handleChatInputCommandInteraction (/root/upe-discord-bot/dist/bot/listeners/interaction-dispatch.listener.js:28:13)
    at async InteractionDispatchListener.execute (/root/upe-discord-bot/dist/bot/listeners/interaction-dispatch.listener.js:11:20)
    at async ListenerExecutionPipeline.executeMain (/root/upe-discord-bot/dist/abc/listener.abc.js:65:13)
```

`client.application.commands.cache` is empty for some reason, which means that `entries` stay empty.

Discord.js docs [recommends](https://discord.js.org/docs/packages/discord.js/main/ApplicationCommandManager:Class) using `fetch()`, presumably because caches are not auto-filled.