### PR TITLE
chore: update GitHub URLs from vinlin24 => uclaupe

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,15 +17,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/vinlin24/upe-discord-bot.git"
+    "url": "git+https://github.com/uclaupe/upe-discord-bot.git"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/vinlin24/upe-discord-bot/issues"
+    "url": "https://github.com/uclaupe/upe-discord-bot/issues"
   },
-  "homepage": "https://github.com/vinlin24/upe-discord-bot",
+  "homepage": "https://github.com/uclaupe/upe-discord-bot",
   "dependencies": {
     "@devraelfreeze/discordjs-pagination": "^2.7.6",
     "@discordjs/rest": "^1.1.0",

--- a/scripts/update-env-repo-secret.sh
+++ b/scripts/update-env-repo-secret.sh
@@ -21,5 +21,5 @@ read -rp 'Proceed ([N]o/[y]es/[v]iew B64)? ' choice
 
 case "$choice" in
     v|V|view) echo "$ENV_FILE_B64" ;;
-    y|Y|yes) echo -n "$ENV_FILE_B64" | gh secret set ENV_FILE_B64 --repo vinlin24/upe-discord-bot ;;
+    y|Y|yes) echo -n "$ENV_FILE_B64" | gh secret set ENV_FILE_B64 --repo uclaupe/upe-discord-bot ;;
 esac

--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -88,7 +88,7 @@ class ReadyListener extends DiscordEventListener<Events.ClientReady> {
     // but tsconfig.json rootDir doesn't allow direct imports from it :/ so
     // unfortunately I shall hard-code this and leave it up to successors to
     // update this.
-    const repoUrl = "https://github.com/vinlin24/upe-discord-bot" as UrlString;
+    const repoUrl = "https://github.com/uclaupe/upe-discord-bot" as UrlString;
     const gitHubCommitUrl = `${repoUrl}/commit/${commitHash}` as UrlString;
     const commitHyperlink = quietHyperlink(
       inlineCode(commitHash),

--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -84,10 +84,6 @@ class ReadyListener extends DiscordEventListener<Events.ClientReady> {
     }
 
     // Ref: https://github.com/<USERNAME>/<REPOSITORY>/commit/<COMMIT_HASH>
-    // TODO: I would've cheesed it with the homepage property from package.json
-    // but tsconfig.json rootDir doesn't allow direct imports from it :/ so
-    // unfortunately I shall hard-code this and leave it up to successors to
-    // update this.
     const repoUrl = "https://github.com/uclaupe/upe-discord-bot" as UrlString;
     const gitHubCommitUrl = `${repoUrl}/commit/${commitHash}` as UrlString;
     const commitHyperlink = quietHyperlink(


### PR DESCRIPTION
Now that the repository has been transferred from @vinlin24 to @uclaupe, replace hard-coded mentions of `vinlin24` with `uclaupe`, used in GitHub-related strings.