### PR TITLE
ci: add lint rule to disallow src/-rooted imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,5 +15,14 @@ export default tseslint.config({
     // Disallow direct access to `process.env`. All environment variables should
     // go through the validated env object exported on startup.
     "node/no-process-env": "error",
+    // Disallow non-relative imports that start with `src/`. These resolve at
+    // runtime only when a path alias or bundler is configured, and silently
+    // break in plain Node / Jest / tsc without one, producing MODULE_NOT_FOUND.
+    "no-restricted-imports": ["error", {
+      patterns: [{
+        regex: "^src/",
+        message: "Use a relative import (e.g. '../../foo') instead of a src/-rooted path.",
+      }],
+    }],
   },
 });

--- a/src/features/moderation/foreach.command.ts
+++ b/src/features/moderation/foreach.command.ts
@@ -12,8 +12,8 @@ import {
 
 import { SlashCommandHandler } from "../../abc/command.abc";
 import type { UserId } from "../../types/branded.types";
-import { SlashCommandCheck } from "src/abc/check.abc";
-import { BotPermissionCheck } from "src/middleware/bot-permission.middleware";
+import { SlashCommandCheck } from "../../abc/check.abc";
+import { BotPermissionCheck } from "../../middleware/bot-permission.middleware";
 
 enum Action {
   Assign = "assign",


### PR DESCRIPTION
Fix to the CI failure in #48: https://github.com/uclaupe/upe-discord-bot/actions/runs/28312796733/job/83880432644

<img width="1336" height="336" alt="image" src="https://github.com/user-attachments/assets/d47da5cb-fbad-4026-8da0-6f12378846f4" />

The problem was due to the two new `import` statements in `src/features/moderation/foreach.command.ts`, which used `src/`-rooted imports instead of relative imports, causing runtime failure when interpreted with `ts-node`. This mistake was likely due to how editors generate import statements by default when accepting import suggestions.

This PR fixes those `import` statements and also introduces a custom lint rule to catch this (this has slipped code review in the past as well).