### PR TITLE
feat: kick unauthorized at-everyone attempts

### DIFF
--- a/src/features/moderation/spam.listener.ts
+++ b/src/features/moderation/spam.listener.ts
@@ -1,0 +1,58 @@
+import { Events, Message, PermissionFlagsBits } from "discord.js";
+
+import { DiscordEventListener } from "../../abc/listener.abc";
+import {
+  ADVISOR_ROLE_ID,
+  EMERITUS_ROLE_ID,
+  OFFICERS_ROLE_ID,
+} from "../../utils/snowflakes.utils";
+
+class SpamListener extends DiscordEventListener<Events.MessageCreate> {
+  public override readonly event = Events.MessageCreate;
+
+  public override async execute(message: Message<true>): Promise<void> {
+    if (this.isProhibitedAtEveryoneAttempt(message)) {
+      const author = message.member;
+      const channelName = message.channel.name;
+      await author?.kick(
+        `Unauthorized @everyone attempt in #${channelName}, likely spam`,
+      );
+    }
+  }
+
+  private isProhibitedAtEveryoneAttempt(message: Message<true>): boolean {
+    // Message doesn't even mention @everyone, not applicable.
+    if (!message.mentions.everyone) {
+      return false;
+    }
+
+    const author = message.member;
+    // Author isn't a `GuildMember` somehow, not applicable.
+    if (!author) {
+      return false;
+    }
+
+    // Author is authorized to mention @everyone in this channel, allowed.
+    const permissions = message.channel.permissionsFor(author);
+    if (permissions.has(PermissionFlagsBits.MentionEveryone)) {
+      return false;
+    }
+
+    // (Fail-safe) Author is an officer/emeritus/advisor, which shouldn't be
+    // caught and punished by this filter ever. This ideally should be covered
+    // by proper permissions setup (above check), but there could be niche edge
+    // cases where maybe a channel has an overwrite to suppress
+    // @everyone-pinging even for them.
+    if (author.roles.cache.hasAny(
+      OFFICERS_ROLE_ID,
+      EMERITUS_ROLE_ID,
+      ADVISOR_ROLE_ID,
+    )) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+export default new SpamListener();

--- a/src/features/moderation/spam.listener.ts
+++ b/src/features/moderation/spam.listener.ts
@@ -79,7 +79,7 @@ class SpamListener extends DiscordEventListener<Events.MessageCreate> {
 
   private isProhibitedAtEveryoneAttempt(message: Message<true>): boolean {
     // Message doesn't even mention @everyone, not applicable.
-    if (!message.mentions.everyone) {
+    if (!this.hasEveryonePing(message.content)) {
       return false;
     }
 
@@ -109,6 +109,33 @@ class SpamListener extends DiscordEventListener<Events.MessageCreate> {
     }
 
     return true;
+  }
+
+  /**
+   * Return whether the `content` contains a raw `@everyone` substring, not
+   * wrapped by code markup (which would disable the ping even if the author had
+   * ping permissions).
+   *
+   * Courtesy of Claude Code.
+   */
+  private hasEveryonePing(content: string): boolean {
+    let stripped = content;
+
+    // Remove fenced code blocks (```...```), which are allowed to span multiple
+    // lines.
+    stripped = stripped.replace(/```[\s\S]*?```/g, '');
+
+    // Remove double-backtick inline code spans (``...``), used so the span's
+    // content can itself contain a literal backtick. Restricted to a single
+    // line, since Discord doesn't let inline code cross lines.
+    stripped = stripped.replace(/``[^\n]*?``/g, '');
+
+    // Remove single-backtick inline code spans (`...`), also single-line only,
+    // and not allowed to contain a backtick itself (that's what the
+    // double-backtick form above is for).
+    stripped = stripped.replace(/`[^`\n]*?`/g, '');
+
+    return stripped.includes("@everyone");
   }
 }
 

--- a/src/features/moderation/spam.listener.ts
+++ b/src/features/moderation/spam.listener.ts
@@ -11,12 +11,7 @@ import {
 } from "discord.js";
 
 import { DiscordEventListener } from "../../abc/listener.abc";
-import {
-  ADVISOR_ROLE_ID,
-  EMERITUS_ROLE_ID,
-  MODERATION_CHANNEL_ID,
-  OFFICERS_ROLE_ID,
-} from "../../utils/snowflakes.utils";
+import { MODERATION_CHANNEL_ID } from "../../utils/snowflakes.utils";
 import channelsService from "../../services/channels.service";
 
 class SpamListener extends DiscordEventListener<Events.MessageCreate> {
@@ -95,16 +90,13 @@ class SpamListener extends DiscordEventListener<Events.MessageCreate> {
       return false;
     }
 
-    // (Fail-safe) Author is an officer/emeritus/advisor, which shouldn't be
-    // caught and punished by this filter ever. This ideally should be covered
-    // by proper permissions setup (above check), but there could be niche edge
-    // cases where maybe a channel has an overwrite to suppress
-    // @everyone-pinging even for them.
-    if (author.roles.cache.hasAny(
-      OFFICERS_ROLE_ID,
-      EMERITUS_ROLE_ID,
-      ADVISOR_ROLE_ID,
-    )) {
+    // (Fail-safe) Author has any role, meaning they're likely not someone who
+    // joined the server just to send spam messages. This isn't a perfect
+    // heuristic but this final check should seldom be hit anyway. It's just
+    // here for the niche edge cases where maybe a channel has a permission
+    // overwrite to suppress @everyone-pinging even for legitimate users, thus
+    // bypassing the check above.
+    if (author.roles.cache.size > 0) {
       return false;
     }
 

--- a/src/features/moderation/spam.listener.ts
+++ b/src/features/moderation/spam.listener.ts
@@ -1,23 +1,80 @@
-import { Events, Message, PermissionFlagsBits } from "discord.js";
+import {
+  bold,
+  channelMention,
+  Colors,
+  EmbedBuilder,
+  Events,
+  inlineCode,
+  Message,
+  PermissionFlagsBits,
+  userMention,
+} from "discord.js";
 
 import { DiscordEventListener } from "../../abc/listener.abc";
 import {
   ADVISOR_ROLE_ID,
   EMERITUS_ROLE_ID,
+  MODERATION_CHANNEL_ID,
   OFFICERS_ROLE_ID,
 } from "../../utils/snowflakes.utils";
+import channelsService from "../../services/channels.service";
 
 class SpamListener extends DiscordEventListener<Events.MessageCreate> {
   public override readonly event = Events.MessageCreate;
 
   public override async execute(message: Message<true>): Promise<void> {
-    if (this.isProhibitedAtEveryoneAttempt(message)) {
-      const author = message.member;
+    await this.handleProhibitedAtEveryoneAttempt(message);
+  }
+
+  private async handleProhibitedAtEveryoneAttempt(
+    message: Message<true>,
+  ): Promise<void> {
+    if (!this.isProhibitedAtEveryoneAttempt(message)) {
+      return;
+    }
+
+    const author = message.member;
+    if (!author) {
+      return;
+    }
+
+    const overviewEmbed = new EmbedBuilder()
+      .setTitle("Suspected Spammer")
+      .setDescription(
+        `${userMention(author.id)} tried to ${inlineCode("@everyone")} in ` +
+        `${channelMention(message.channelId)}.`,
+      )
+      .setColor(Colors.Red);
+
+    const echoEmbed = new EmbedBuilder()
+      .setTitle("Suspected Spam Message")
+      .setDescription(message.content)
+      .setFooter({ text: `Included ${message.attachments.size} attachments` })
+      .setColor(Colors.Red);
+
+    if (author.kickable) {
       const channelName = message.channel.name;
-      await author?.kick(
+      await author.kick(
         `Unauthorized @everyone attempt in #${channelName}, likely spam`,
       );
+      overviewEmbed
+        .setTitle("Kicked Suspected Spammer")
+        .setDescription(
+          `${overviewEmbed.data.description} They have been ${bold("kicked")}.`,
+        )
+        .setColor(Colors.Yellow);
     }
+
+    if (message.deletable) {
+      await message.delete();
+      echoEmbed
+        .setTitle("Deleted Suspected Spam Message")
+        .setColor(Colors.Yellow);
+    }
+
+    await channelsService.sendToChannel(MODERATION_CHANNEL_ID, {
+      embeds: [overviewEmbed, echoEmbed],
+    });
   }
 
   private isProhibitedAtEveryoneAttempt(message: Message<true>): boolean {

--- a/src/services/channels.service.ts
+++ b/src/services/channels.service.ts
@@ -24,6 +24,7 @@ import {
   DEVELOPER_ROLE_ID,
   UPE_GUILD_ID,
 } from "../utils/snowflakes.utils";
+import type { ChannelId } from "../types/branded.types";
 
 class ChannelService {
   private client: Client<true> | null = null;
@@ -63,6 +64,31 @@ class ChannelService {
       return null;
     }
     return this.logsChannel;
+  }
+
+  public async sendToChannel(
+    channelId: ChannelId,
+    options: string | MessagePayload | MessageCreateOptions,
+  ): Promise<Message | null> {
+    const upe = this.getUpe();
+    const channel = await upe.channels.fetch(channelId);
+    if (channel === null) {
+      console.error(`tried to send to unknown channel (ID: ${channelId}`);
+      return null;
+    }
+    if (!channel.isTextBased()) {
+      console.error(`tried to send to non-text channel (ID: ${channelId})`);
+      return null;
+    }
+    try {
+      return await channel.send(options);
+    }
+    catch (error) {
+      console.error(
+        `failed to send to channel (ID: ${channelId}), doing nothing`,
+      );
+      return null;
+    }
   }
 
   public async sendDev(

--- a/src/utils/snowflakes.utils.ts
+++ b/src/utils/snowflakes.utils.ts
@@ -26,6 +26,7 @@ export const EVP_ROLE_ID = "778819652775706645" as RoleId;
 
 // Title role IDs.
 
+export const ADVISOR_ROLE_ID = "976178843855503372" as RoleId;
 export const ALUM_ROLE_ID = "828720200676409344" as RoleId;
 export const EMERITUS_ROLE_ID = "854916094326341633" as RoleId;
 export const ADMINS_ROLE_ID = "778437029280612353" as RoleId;


### PR DESCRIPTION
## Summary

Add a new message creation event listener to detect and punish spam, starting with those that try to `@everyone` (a common observed pattern in the spam messages seen to date).

## Motivation

As requested in `#moderation`, in response to the continuous `@everyone` spam message attempts observed in channels like `#general`.

There are likely bots out there that can already do this out-of-the-box or with some configuration, but I figured doing it in-house (1) avoids one more 3rd party bot added to the server and (2) gives us more flexibility in detection criteria & punishment actions.

## Details

Detection criteria:

- [x] Mentions `@everyone`, accounting for code Markdown (an `@everyone` wrapped in backticks wouldn't be a ping regardless of if the author had permission to, so it's allowed).
- [x] Author does not have permission to mention `@everyone` in the current channel, accounting for permission overwrites (if you have the _permission_ to actually issue the ping with the `@everyone` string, you should be allowed to do so).
- [x] Author does not have any role (spammers usually just join the server to send spam messages and wouldn't have any role).

Punishment actions:

1. **Kick** the author, if the bot is able. Send an acknowledgement embed to `#moderation` in any case.
2. **Delete** the message, if the bot is able. Send an embed to `#moderation` in any case echoing the content of the deleted message.

> [!CAUTION]
>
> **Increased privilege:** to implement kicking, the **Kick Members** permission was added to the bot role's base permission set.